### PR TITLE
[CHAD] Refactor command files to import colors from shared utils module

### DIFF
--- a/src/approve.ts
+++ b/src/approve.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type {
@@ -9,19 +10,6 @@ import type {
   ApprovalLockData,
   ApprovalHistoryEntry,
 } from './types/index.js';
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-  blue: '\x1b[34m',
-};
 
 interface ApproveOptions extends BaseCommandOptions {
   issueNumber?: number;

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 
 import { join, dirname, resolve, basename } from 'path';
 import { execSync, spawn } from 'child_process';
 import { randomUUID } from 'crypto';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type { BaseCommandOptions } from './types/index.js';
@@ -115,18 +116,6 @@ interface BenchmarkOptions extends BaseCommandOptions {
   dryRun?: boolean;
 }
 
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 // Standard benchmark tasks for quick mode
 const QUICK_BENCHMARK_TASKS: BenchmarkTask[] = [

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync } f
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
+import { colors } from './utils/colors.js';
 
 export interface CleanupOptions {
   config?: string;
@@ -32,18 +33,6 @@ interface CleanupResult {
   };
 }
 
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  green: '\x1b[32m',
-  yellow: '\x1b[33m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-  blue: '\x1b[34m',
-};
 
 // Parse YAML value (simple key: value extraction)
 function parseYamlValue(content: string, key: string): string | null {

--- a/src/config-export-import.ts
+++ b/src/config-export-import.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
 import { maskSecrets, maskObject } from './utils/secrets.js';
+import { colors } from './utils/colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -37,16 +38,6 @@ interface ExportBundle {
   templates: Record<string, string>;
 }
 
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  magenta: '\x1b[35m',
-};
 
 // Patterns for detecting secrets/sensitive data in config
 const SECRET_PATTERNS = [

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync, spawnSync } from 'child_process';
+import { colors } from './utils/colors.js';
 
 export interface DiffOptions {
   config?: string;
@@ -43,21 +44,6 @@ interface CommitInfo {
   date: string;
 }
 
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-  white: '\x1b[37m',
-  bgRed: '\x1b[41m',
-  bgGreen: '\x1b[42m',
-};
 
 // Parse nested YAML value
 function parseYamlNested(content: string, parent: string, key: string): string | null {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { validateTemplateVariables, TemplateValidationResult } from './validate.js';
 import { maskSecrets, maskObject, setMaskingDisabled } from './utils/secrets.js';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type {
@@ -17,19 +18,6 @@ interface DoctorOptions extends BaseCommandOptions {
   fix?: boolean;
   mask?: boolean;  // --no-mask flag sets this to false
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  green: '\x1b[32m',
-  yellow: '\x1b[33m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-  blue: '\x1b[34m',
-};
 
 // Parse YAML value (simple key: value extraction)
 function parseYamlValue(content: string, key: string): string | null {
@@ -841,7 +829,7 @@ function printReport(report: HealthReport): void {
   console.log(`${colors.reset}`);
 
   // Health score with color coding
-  let scoreColor = colors.green;
+  let scoreColor: string = colors.green;
   if (report.healthScore < 70) {
     scoreColor = colors.red;
   } else if (report.healthScore < 85) {

--- a/src/estimate.ts
+++ b/src/estimate.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type {
@@ -67,19 +68,6 @@ interface EstimateResult {
   tasksWithinBudget?: number;
   budgetLimit?: number;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 // Default estimates when no historical data is available
 const DEFAULT_ESTIMATES = {

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type {
@@ -27,19 +28,6 @@ interface CategoryStats {
   avgDuration: number;
   totalCost: number;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 function formatDuration(seconds: number): string {
   const hours = Math.floor(seconds / 3600);

--- a/src/pause.ts
+++ b/src/pause.ts
@@ -1,5 +1,6 @@
 import { existsSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type { BaseCommandOptions, ProgressData, PauseLockData } from './types/index.js';
@@ -8,17 +9,6 @@ interface PauseOptions extends BaseCommandOptions {
   for?: string;
   reason?: string;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-};
 
 /**
  * Parse duration string (e.g., "30m", "2h", "1h30m") to milliseconds

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
+import { colors } from './utils/colors.js';
 
 // Queue task from GitHub project board
 interface QueueTask {
@@ -47,18 +48,6 @@ interface QueuePromoteOptions extends QueueOptions {
   issueNumber: number;
 }
 
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 // Parse YAML value (simple key: value extraction)
 function parseYamlValue(content: string, key: string): string | null {

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type {
@@ -22,19 +23,6 @@ export interface ReplayOptions extends BaseCommandOptions {
   dryRun?: boolean;
   timeout?: number;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 // Parse YAML value (simple key: value extraction)
 function parseYamlValue(content: string, key: string): string | null {

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -2,6 +2,7 @@ import { existsSync, unlinkSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type { BaseCommandOptions, ProgressData, PauseLockData } from './types/index.js';
@@ -12,17 +13,6 @@ const __dirname = dirname(__filename);
 interface ResumeOptions extends BaseCommandOptions {
   restart?: boolean;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-};
 
 export async function resume(options: ResumeOptions = {}): Promise<void> {
   const cwd = process.cwd();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
+import { colors } from './utils/colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,17 +30,6 @@ interface ConfigValues {
   slackWebhookUrl: string;
   discordWebhookUrl: string;
 }
-
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  magenta: '\x1b[35m',
-};
 
 function execCommandSilent(command: string): string | null {
   try {

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve, basename } from 'path';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
+import { colors } from './utils/colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,19 +12,6 @@ const __dirname = dirname(__filename);
 const packageJsonPath = join(__dirname, '..', 'package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 const CHADGI_VERSION = packageJson.version;
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-};
 
 // Snapshot metadata
 interface SnapshotMetadata {

--- a/src/start.ts
+++ b/src/start.ts
@@ -11,22 +11,10 @@ import {
   WorkspaceRepoConfig,
 } from './workspace.js';
 import { setMaskingDisabled } from './utils/secrets.js';
+import { colors } from './utils/colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-// Colors for console output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  magenta: '\x1b[35m',
-  blue: '\x1b[34m',
-};
 
 interface StartOptions {
   config?: string;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type { BaseCommandOptions, SessionStats, TaskResult } from './types/index.js';
@@ -7,18 +8,6 @@ import type { BaseCommandOptions, SessionStats, TaskResult } from './types/index
 interface StatsOptions extends BaseCommandOptions {
   last?: number;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  purple: '\x1b[35m',
-  cyan: '\x1b[36m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-};
 
 function formatDuration(seconds: number): string {
   const hours = Math.floor(seconds / 3600);

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -21,6 +21,10 @@ export const colors = {
   cyan: '\x1b[36m',
   white: '\x1b[37m',
   gray: '\x1b[90m',
+
+  // Background colors
+  bgRed: '\x1b[41m',
+  bgGreen: '\x1b[42m',
 } as const;
 
 export type ColorName = keyof typeof colors;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, watchFile, unwatchFile, statSync } from 'fs';
 import { join, dirname, resolve } from 'path';
+import { colors } from './utils/colors.js';
 
 // Import shared types
 import type { BaseCommandOptions, ProgressData, RecentTool } from './types/index.js';
@@ -34,20 +35,6 @@ interface WatchStatus {
   recentTools?: RecentTool[];
   lastUpdated?: string;
 }
-
-// Color codes for terminal output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  purple: '\x1b[35m',
-  blue: '\x1b[34m',
-  white: '\x1b[37m',
-};
 
 // ANSI escape codes for cursor control
 const cursor = {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve, basename, isAbsolute } from 'path';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
+import { colors } from './utils/colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,19 +16,6 @@ const CHADGI_VERSION = packageJson.version;
 // Default workspace config filename
 export const WORKSPACE_CONFIG_FILENAME = 'workspace.yaml';
 export const WORKSPACE_DIR = '.chadgi';
-
-// Colors for console output
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  yellow: '\x1b[33m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
-  magenta: '\x1b[35m',
-  blue: '\x1b[34m',
-};
 
 // Workspace configuration interfaces
 export interface WorkspaceRepoConfig {

--- a/tests/test-cleanup.sh
+++ b/tests/test-cleanup.sh
@@ -327,7 +327,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 27: cleanup.ts uses colored output"
 
-if grep -q "colors\s*=\|\\\\x1b\[" "$PROJECT_ROOT/src/cleanup.ts"; then
+if grep -q "colors\s*=\|\\\\x1b\[\|from './utils/colors.js'" "$PROJECT_ROOT/src/cleanup.ts"; then
     pass "cleanup.ts uses colored output"
 else
     fail "cleanup.ts should use colored output"

--- a/tests/test-config-export-import.sh
+++ b/tests/test-config-export-import.sh
@@ -438,7 +438,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 37: Color output support"
 
-if grep -q "colors\s*=" "$PROJECT_ROOT/src/config-export-import.ts"; then
+if grep -q "colors\s*=\|from './utils/colors.js'" "$PROJECT_ROOT/src/config-export-import.ts"; then
     pass "Color output support implemented"
 else
     fail "Color output support should be implemented"

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -239,7 +239,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 19: doctor.ts uses colored output"
 
-if grep -q "colors\s*=\|\\\\x1b\[" "$PROJECT_ROOT/src/doctor.ts"; then
+if grep -q "colors\s*=\|\\\\x1b\[\|from './utils/colors.js'" "$PROJECT_ROOT/src/doctor.ts"; then
     pass "doctor.ts uses colored output"
 else
     fail "doctor.ts should use colored output"

--- a/tests/test-queue.sh
+++ b/tests/test-queue.sh
@@ -426,7 +426,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 36: queue.ts has color constants"
 
-if grep -q "colors = {" "$PROJECT_ROOT/src/queue.ts"; then
+if grep -q "colors = {\|from './utils/colors.js'" "$PROJECT_ROOT/src/queue.ts"; then
     pass "Color constants exist"
 else
     fail "queue should have color constants for output"

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -294,7 +294,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 24: setup.ts has color output support"
 
-if grep -q "colors\s*=" "$PROJECT_ROOT/src/setup.ts"; then
+if grep -q "colors\s*=\|from './utils/colors.js'" "$PROJECT_ROOT/src/setup.ts"; then
     pass "setup.ts has color output support"
 else
     fail "setup.ts should have color output support"

--- a/tests/test-snapshot.sh
+++ b/tests/test-snapshot.sh
@@ -420,7 +420,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 35: Color output support"
 
-if grep -q "colors\s*=" "$PROJECT_ROOT/src/snapshot.ts"; then
+if grep -q "colors\s*=\|from './utils/colors.js'" "$PROJECT_ROOT/src/snapshot.ts"; then
     pass "Color output support implemented"
 else
     fail "Color output support should be implemented"

--- a/tests/test-watch.sh
+++ b/tests/test-watch.sh
@@ -184,7 +184,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 14: watch.ts has color constants"
 
-if grep -q "colors = {" "$PROJECT_ROOT/src/watch.ts"; then
+if grep -q "colors = {\|from './utils/colors.js'" "$PROJECT_ROOT/src/watch.ts"; then
     pass "Color constants exist"
 else
     fail "watch should have color constants for output"


### PR DESCRIPTION
## Summary
- Replaced local color definitions with imports from `src/utils/colors.ts` in 18 command files
- Added `bgRed` and `bgGreen` background colors to the shared colors module (used by diff.ts)
- Fixed TypeScript type narrowing issue in doctor.ts for dynamic color assignment
- Updated 7 integration test files to recognize the shared colors import pattern
- Eliminated ~180 lines of duplicated ANSI color code definitions

## Test Plan
- [x] Run `npm run build` - TypeScript compilation succeeds
- [x] Run `npm test` - All unit tests (Jest) and integration tests (Bash) pass
- [x] Verify color output still works correctly in command output (colors are imported from shared module)

Closes #72

---
\`\`\`
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
\`\`\`
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates terminal color handling across CLI commands by importing `colors` from `utils/colors.ts`, removing duplicate inline ANSI palettes. Adds background colors (`bgRed`, `bgGreen`) to the shared module and uses them (e.g., in `diff.ts`). Fixes a TypeScript type annotation for dynamic color selection in `doctor.ts`. Updates multiple integration tests to recognize the shared colors import pattern.
> 
> - Replace inline color constants with `import { colors } from 
>   `utils/colors.js`` in command files (e.g., `approve.ts`, `benchmark.ts`, `cleanup.ts`, `config-export-import.ts`, `diff.ts`, `doctor.ts`, `estimate.ts`, `insights.ts`, `pause.ts`, `resume.ts`, `setup.ts`, `snapshot.ts`, `start.ts`, `stats.ts`, `watch.ts`, `workspace.ts`)
> - Extend `utils/colors.ts` with `bgRed`/`bgGreen`
> - Minor type fix: `let scoreColor: string` in `doctor.ts`
> - Update tests (`tests/test-*.sh`) to accept the shared colors import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eeb390749118b003d663c55f098dca428dae57b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->