### PR TITLE
[CHAD] Eliminate duplicate YAML parsing functions across command files

### DIFF
--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
 
 export interface CleanupOptions {
   config?: string;
@@ -31,39 +32,6 @@ interface CleanupResult {
     logsDeleted: number;
     totalDeleted: number;
   };
-}
-
-
-// Parse YAML value (simple key: value extraction)
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 /**

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync, spawnSync } from 'child_process';
 import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
 
 export interface DiffOptions {
   config?: string;
@@ -42,30 +43,6 @@ interface CommitInfo {
   message: string;
   author: string;
   date: string;
-}
-
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 // Get current git branch

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { validateTemplateVariables, TemplateValidationResult } from './validate.js';
 import { maskSecrets, maskObject, setMaskingDisabled } from './utils/secrets.js';
 import { colors } from './utils/colors.js';
+import { parseYamlValue, parseYamlNested } from './utils/config.js';
 
 // Import shared types
 import type {
@@ -18,39 +19,6 @@ interface DoctorOptions extends BaseCommandOptions {
   fix?: boolean;
   mask?: boolean;  // --no-mask flag sets this to false
 }
-
-// Parse YAML value (simple key: value extraction)
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
-}
-
 
 /**
  * Check GitHub API rate limit status

--- a/src/estimate.ts
+++ b/src/estimate.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
 
 // Import shared types
 import type {
@@ -112,38 +113,6 @@ function calculateStdDev(values: number[]): number {
   const avg = values.reduce((a, b) => a + b, 0) / values.length;
   const squaredDiffs = values.map((v) => Math.pow(v - avg, 2));
   return Math.sqrt(squaredDiffs.reduce((a, b) => a + b, 0) / values.length);
-}
-
-// Parse YAML value (simple key: value extraction)
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 // Load and merge data from both stats and metrics files

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { colors } from './utils/colors.js';
+import { parseYamlValue, parseYamlNested, parseYamlBoolean } from './utils/config.js';
 
 // Queue task from GitHub project board
 interface QueueTask {
@@ -46,45 +47,6 @@ interface QueueSkipOptions extends QueueOptions {
 
 interface QueuePromoteOptions extends QueueOptions {
   issueNumber: number;
-}
-
-
-// Parse YAML value (simple key: value extraction)
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
-}
-
-// Parse YAML boolean value
-function parseYamlBoolean(content: string, parent: string, key: string): boolean {
-  const value = parseYamlNested(content, parent, key);
-  return value === 'true';
 }
 
 // Parse dependency patterns from config

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from 'path';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
 
 // Import shared types
 import type {
@@ -22,38 +23,6 @@ export interface ReplayOptions extends BaseCommandOptions {
   yes?: boolean;
   dryRun?: boolean;
   timeout?: number;
-}
-
-// Parse YAML value (simple key: value extraction)
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-// Parse nested YAML value
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 function formatDuration(seconds: number): string {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
 import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -130,35 +131,6 @@ async function promptSelect(rl: ReturnType<typeof createInterface>, question: st
   }
   // Default to first option if invalid
   return options[0].value;
-}
-
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 function loadExistingConfig(configPath: string): Partial<ConfigValues> {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { maskSecrets, setMaskingDisabled } from './utils/secrets.js';
+import { parseYamlValue, parseYamlNested } from './utils/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,36 +40,6 @@ function getCommandVersion(command: string): string | null {
   } catch {
     return null;
   }
-}
-
-function parseYamlValue(content: string, key: string): string | null {
-  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-  if (match) {
-    return match[1].replace(/["']/g, '').replace(/#.*$/, '').trim();
-  }
-  return null;
-}
-
-function parseYamlNested(content: string, parent: string, key: string): string | null {
-  const lines = content.split('\n');
-  let inParent = false;
-
-  for (const line of lines) {
-    if (line.match(new RegExp(`^${parent}:`))) {
-      inParent = true;
-      continue;
-    }
-    if (inParent && line.match(/^[a-z]/)) {
-      inParent = false;
-    }
-    if (inParent && line.match(new RegExp(`^\\s+${key}:`))) {
-      const value = line.split(':')[1];
-      if (value) {
-        return value.replace(/["']/g, '').replace(/#.*$/, '').trim();
-      }
-    }
-  }
-  return null;
 }
 
 // Config inheritance support

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -74,22 +74,6 @@ export interface WorkspaceStatusOptions {
   limit?: number;
 }
 
-// Helper to parse simple YAML values
-function parseYamlValue(content: string, key: string): string | undefined {
-  const regex = new RegExp(`^${key}:\\s*(.*)$`, 'm');
-  const match = content.match(regex);
-  if (match) {
-    let value = match[1].trim();
-    // Remove quotes if present
-    if ((value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    return value || undefined;
-  }
-  return undefined;
-}
-
 // Parse YAML to object (simplified parser for workspace config)
 function parseYamlToObject(content: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Removed local `parseYamlValue`, `parseYamlNested`, and `parseYamlBoolean` function definitions from 9 command files
- Added imports from the shared `src/utils/config.ts` module instead
- Files updated: validate.ts, queue.ts, doctor.ts, estimate.ts, replay.ts, cleanup.ts, diff.ts, setup.ts, workspace.ts
- Removed ~268 lines of duplicate code
- No behavior changes - all existing tests pass

## Test Plan
- [x] Run `npm run build` - passes
- [x] Run `npm test` - all unit and integration tests pass
- [x] Verify no duplicate function definitions remain: `grep -r "function parseYaml" src/` shows only utils/config.ts
- [x] Existing comprehensive tests in `src/__tests__/utils/config.test.ts` cover all parsing functions

Closes #76

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `cleanup` command and consolidates YAML parsing across commands.
> 
> - Adds `src/cleanup.ts` to clean orphaned branches, old diagnostics, and rotated logs; supports `--dry-run`, `--yes`, `--days`, and `--json`, with detailed reporting
> - Replaces ad-hoc `parseYamlValue`/`parseYamlNested`/`parseYamlBoolean` with imports from `utils/config.ts` in `validate.ts`, `queue.ts`, `doctor.ts`, `estimate.ts`, `replay.ts`, `cleanup.ts`, `diff.ts`, `setup.ts`, and `workspace.ts`, removing duplicate helpers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9095c26083503c8ec5eb6f768a0021d96c7f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->