### PR TITLE
[CHAD] Add CLI numeric option validation with bounds checking

### DIFF
--- a/src/__tests__/utils/validation.test.ts
+++ b/src/__tests__/utils/validation.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Unit tests for src/utils/validation.ts
+ *
+ * Tests numeric validation utilities for CLI options.
+ */
+
+import { jest } from '@jest/globals';
+import {
+  validateNumeric,
+  createNumericParser,
+  validateNumericOptions,
+  formatConstraintBounds,
+  NUMERIC_CONSTRAINTS,
+  type NumericConstraint,
+} from '../../utils/validation.js';
+
+describe('validateNumeric', () => {
+  describe('basic integer parsing', () => {
+    it('should accept valid positive integers', () => {
+      const result = validateNumeric('42', 'test', { min: 0, integer: true });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(42);
+    });
+
+    it('should accept zero when min is 0', () => {
+      const result = validateNumeric('0', 'timeout', 'timeout');
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(0);
+    });
+
+    it('should reject non-numeric input', () => {
+      const result = validateNumeric('abc', 'test', { min: 0, integer: true });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('not a valid integer');
+    });
+
+    it('should reject empty string', () => {
+      const result = validateNumeric('', 'test', { min: 0, integer: true });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('not a valid integer');
+    });
+
+    it('should reject floating point when integer is required', () => {
+      const result = validateNumeric('3.5', 'test', { integer: true, min: 1 });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('must be an integer');
+    });
+  });
+
+  describe('floating point parsing', () => {
+    it('should accept valid float values', () => {
+      const result = validateNumeric('1.5', 'budget', { min: 0.01 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(1.5);
+    });
+
+    it('should accept integer values as floats', () => {
+      const result = validateNumeric('5', 'budget', { min: 0.01 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(5);
+    });
+  });
+
+  describe('minimum bound checking', () => {
+    it('should accept value at minimum bound', () => {
+      const result = validateNumeric('100', 'interval', 'interval');
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(100);
+    });
+
+    it('should reject value below minimum bound', () => {
+      const result = validateNumeric('50', 'interval', 'interval');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('at least 100ms');
+    });
+
+    it('should reject negative values when min is 0', () => {
+      const result = validateNumeric('-5', 'timeout', 'timeout');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('non-negative');
+    });
+
+    it('should reject zero when min is 1', () => {
+      const result = validateNumeric('0', 'limit', 'limit');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('positive integer');
+    });
+  });
+
+  describe('maximum bound checking', () => {
+    it('should accept value at maximum bound', () => {
+      const result = validateNumeric('36500', 'days', 'days');
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(36500);
+    });
+
+    it('should reject value above maximum bound', () => {
+      const result = validateNumeric('999999', 'days', 'days');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('1-36500');
+    });
+  });
+
+  describe('predefined constraint names', () => {
+    it('should use timeout constraint correctly', () => {
+      const valid = validateNumeric('30', 'timeout', 'timeout');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(30);
+
+      const invalid = validateNumeric('-1', 'timeout', 'timeout');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use interval constraint correctly', () => {
+      const valid = validateNumeric('2000', 'interval', 'interval');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(2000);
+
+      const invalid = validateNumeric('50', 'interval', 'interval');
+      expect(invalid.valid).toBe(false);
+      expect(invalid.error).toContain('at least 100ms');
+    });
+
+    it('should use limit constraint correctly', () => {
+      const valid = validateNumeric('10', 'limit', 'limit');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(10);
+
+      const invalid = validateNumeric('0', 'limit', 'limit');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use days constraint correctly', () => {
+      const valid = validateNumeric('30', 'days', 'days');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(30);
+
+      const invalidZero = validateNumeric('0', 'days', 'days');
+      expect(invalidZero.valid).toBe(false);
+
+      const invalidHigh = validateNumeric('50000', 'days', 'days');
+      expect(invalidHigh.valid).toBe(false);
+    });
+
+    it('should use budget constraint correctly', () => {
+      const valid = validateNumeric('2.50', 'budget', 'budget');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(2.5);
+
+      const invalid = validateNumeric('0', 'budget', 'budget');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use iterations constraint correctly', () => {
+      const valid = validateNumeric('5', 'iterations', 'iterations');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(5);
+
+      const invalid = validateNumeric('0', 'iterations', 'iterations');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use issueNumber constraint correctly', () => {
+      const valid = validateNumeric('123', 'pr', 'issueNumber');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(123);
+
+      const invalid = validateNumeric('0', 'pr', 'issueNumber');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use priority constraint correctly', () => {
+      const validZero = validateNumeric('0', 'priority', 'priority');
+      expect(validZero.valid).toBe(true);
+      expect(validZero.value).toBe(0);
+
+      const validPositive = validateNumeric('5', 'priority', 'priority');
+      expect(validPositive.valid).toBe(true);
+
+      const invalid = validateNumeric('-1', 'priority', 'priority');
+      expect(invalid.valid).toBe(false);
+    });
+
+    it('should use sessionCount constraint correctly', () => {
+      const valid = validateNumeric('5', 'last', 'sessionCount');
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(5);
+
+      const invalid = validateNumeric('0', 'last', 'sessionCount');
+      expect(invalid.valid).toBe(false);
+    });
+  });
+
+  describe('custom constraints', () => {
+    it('should accept custom constraint object', () => {
+      const constraint: NumericConstraint = {
+        min: 10,
+        max: 100,
+        integer: true,
+        errorMessage: 'Value must be between 10 and 100',
+      };
+
+      const valid = validateNumeric('50', 'custom', constraint);
+      expect(valid.valid).toBe(true);
+      expect(valid.value).toBe(50);
+
+      const invalid = validateNumeric('5', 'custom', constraint);
+      expect(invalid.valid).toBe(false);
+      expect(invalid.error).toContain('between 10 and 100');
+    });
+  });
+});
+
+describe('createNumericParser', () => {
+  let mockExit: jest.SpiedFunction<typeof process.exit>;
+  let mockConsoleError: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    mockConsoleError.mockRestore();
+  });
+
+  it('should return parsed value for valid input', () => {
+    const parser = createNumericParser('timeout', 'timeout');
+    expect(parser('30')).toBe(30);
+  });
+
+  it('should exit with code 1 for invalid input', () => {
+    const parser = createNumericParser('timeout', 'timeout');
+
+    expect(() => parser('-5')).toThrow('process.exit called');
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockConsoleError).toHaveBeenCalled();
+  });
+
+  it('should print colored error message', () => {
+    const parser = createNumericParser('interval', 'interval');
+
+    expect(() => parser('50')).toThrow('process.exit called');
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('at least 100ms')
+    );
+  });
+});
+
+describe('validateNumericOptions', () => {
+  it('should validate multiple options successfully', () => {
+    const options = { timeout: 30, limit: 10, days: 7 };
+    const constraints = {
+      timeout: 'timeout' as const,
+      limit: 'limit' as const,
+      days: 'days' as const,
+    };
+
+    const result = validateNumericOptions(options, constraints);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should collect all errors for invalid options', () => {
+    const options = { timeout: -1, limit: 0, days: 50000 };
+    const constraints = {
+      timeout: 'timeout' as const,
+      limit: 'limit' as const,
+      days: 'days' as const,
+    };
+
+    const result = validateNumericOptions(options, constraints);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should skip undefined options', () => {
+    const options = { timeout: undefined, limit: 10 };
+    const constraints = {
+      timeout: 'timeout' as const,
+      limit: 'limit' as const,
+    };
+
+    const result = validateNumericOptions(options, constraints);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('formatConstraintBounds', () => {
+  it('should format integer constraints', () => {
+    const result = formatConstraintBounds('limit');
+    expect(result).toContain('integer');
+    expect(result).toContain('>= 1');
+  });
+
+  it('should format range constraints', () => {
+    const result = formatConstraintBounds('days');
+    expect(result).toContain('1-36500');
+  });
+
+  it('should format minimum-only constraints', () => {
+    const result = formatConstraintBounds('timeout');
+    expect(result).toContain('>= 0');
+  });
+
+  it('should format float constraints', () => {
+    const result = formatConstraintBounds('budget');
+    expect(result).toContain('>= 0.01');
+    expect(result).not.toContain('integer');
+  });
+
+  it('should format custom constraints', () => {
+    const constraint: NumericConstraint = {
+      min: 5,
+      max: 20,
+      integer: true,
+    };
+    const result = formatConstraintBounds(constraint);
+    expect(result).toContain('integer');
+    expect(result).toContain('5-20');
+  });
+});
+
+describe('NUMERIC_CONSTRAINTS', () => {
+  it('should have all required constraint definitions', () => {
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('timeout');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('interval');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('limit');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('days');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('budget');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('iterations');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('issueNumber');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('priority');
+    expect(NUMERIC_CONSTRAINTS).toHaveProperty('sessionCount');
+  });
+
+  it('should have correct timeout constraint', () => {
+    expect(NUMERIC_CONSTRAINTS.timeout.min).toBe(0);
+    expect(NUMERIC_CONSTRAINTS.timeout.integer).toBe(true);
+  });
+
+  it('should have correct interval constraint', () => {
+    expect(NUMERIC_CONSTRAINTS.interval.min).toBe(100);
+    expect(NUMERIC_CONSTRAINTS.interval.integer).toBe(true);
+  });
+
+  it('should have correct days constraint with upper bound', () => {
+    expect(NUMERIC_CONSTRAINTS.days.min).toBe(1);
+    expect(NUMERIC_CONSTRAINTS.days.max).toBe(36500);
+  });
+
+  it('should have correct budget constraint for floats', () => {
+    expect(NUMERIC_CONSTRAINTS.budget.min).toBe(0.01);
+    // Budget constraint doesn't have integer: true, so it accepts floats
+    expect('integer' in NUMERIC_CONSTRAINTS.budget).toBe(false);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -139,3 +139,15 @@ export {
   maskSensitiveKeys,
   createMaskedLogger,
 } from './secrets.js';
+
+// Validation
+export {
+  NUMERIC_CONSTRAINTS,
+  validateNumeric,
+  createNumericParser,
+  validateNumericOptions,
+  formatConstraintBounds,
+  type NumericConstraint,
+  type ConstraintName,
+  type ValidationResult,
+} from './validation.js';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,242 @@
+/**
+ * CLI numeric option validation utilities.
+ *
+ * Provides validation functions for numeric CLI options with bounds checking
+ * to prevent invalid values that could cause runtime errors or confusing behavior.
+ */
+
+import { colors } from './colors.js';
+
+/**
+ * Validation constraint configuration
+ */
+export interface NumericConstraint {
+  /** Minimum allowed value (inclusive) */
+  min?: number;
+  /** Maximum allowed value (inclusive) */
+  max?: number;
+  /** If true, value must be an integer */
+  integer?: boolean;
+  /** Custom error message override */
+  errorMessage?: string;
+}
+
+/**
+ * Predefined constraint sets for common CLI options
+ */
+export const NUMERIC_CONSTRAINTS = {
+  /** Timeout in minutes: >= 0 (0 = disabled) */
+  timeout: {
+    min: 0,
+    integer: true,
+    errorMessage: 'Timeout must be a non-negative integer (0 = disabled)',
+  },
+  /** Interval in milliseconds: >= 100 (prevent tight loops) */
+  interval: {
+    min: 100,
+    integer: true,
+    errorMessage: 'Interval must be at least 100ms to prevent tight loops',
+  },
+  /** Limit count: > 0 */
+  limit: {
+    min: 1,
+    integer: true,
+    errorMessage: 'Limit must be a positive integer',
+  },
+  /** Days count: > 0 */
+  days: {
+    min: 1,
+    max: 36500, // ~100 years, reasonable upper bound
+    integer: true,
+    errorMessage: 'Days must be a positive integer (1-36500)',
+  },
+  /** Budget amount: > 0 */
+  budget: {
+    min: 0.01,
+    errorMessage: 'Budget must be a positive number',
+  },
+  /** Iterations count: > 0 */
+  iterations: {
+    min: 1,
+    integer: true,
+    errorMessage: 'Iterations must be a positive integer',
+  },
+  /** PR/Issue number: > 0 and integer */
+  issueNumber: {
+    min: 1,
+    integer: true,
+    errorMessage: 'Issue/PR number must be a positive integer',
+  },
+  /** Priority level: >= 0 */
+  priority: {
+    min: 0,
+    integer: true,
+    errorMessage: 'Priority must be a non-negative integer',
+  },
+  /** Session count (--last): > 0 */
+  sessionCount: {
+    min: 1,
+    integer: true,
+    errorMessage: 'Session count must be a positive integer',
+  },
+} as const;
+
+export type ConstraintName = keyof typeof NUMERIC_CONSTRAINTS;
+
+/**
+ * Validation result for error reporting
+ */
+export interface ValidationResult {
+  valid: boolean;
+  value?: number;
+  error?: string;
+}
+
+/**
+ * Validates a numeric value against constraints.
+ *
+ * @param value - The value to validate (string from CLI input)
+ * @param optionName - Name of the option for error messages
+ * @param constraint - Constraint configuration or predefined constraint name
+ * @returns Validation result with parsed value or error message
+ */
+export function validateNumeric(
+  value: string,
+  optionName: string,
+  constraint: NumericConstraint | ConstraintName
+): ValidationResult {
+  // Resolve predefined constraint name to configuration
+  const config: NumericConstraint =
+    typeof constraint === 'string'
+      ? NUMERIC_CONSTRAINTS[constraint]
+      : constraint;
+
+  // Parse the value - always use parseFloat first for proper detection
+  const parsed = parseFloat(value);
+
+  // Check if parsing succeeded
+  if (isNaN(parsed)) {
+    const typeDesc = config.integer ? 'integer' : 'number';
+    return {
+      valid: false,
+      error: `Invalid ${optionName}: "${value}" is not a valid ${typeDesc}`,
+    };
+  }
+
+  // Check integer constraint (handles cases like "3.5" when integer is required)
+  if (config.integer && !Number.isInteger(parsed)) {
+    return {
+      valid: false,
+      error: `Invalid ${optionName}: value must be an integer`,
+    };
+  }
+
+  // Check minimum bound
+  if (config.min !== undefined && parsed < config.min) {
+    const errorMsg =
+      config.errorMessage ||
+      `Invalid ${optionName}: value must be >= ${config.min}`;
+    return { valid: false, error: errorMsg };
+  }
+
+  // Check maximum bound
+  if (config.max !== undefined && parsed > config.max) {
+    const errorMsg =
+      config.errorMessage ||
+      `Invalid ${optionName}: value must be <= ${config.max}`;
+    return { valid: false, error: errorMsg };
+  }
+
+  return { valid: true, value: parsed };
+}
+
+/**
+ * Creates a Commander option parser function that validates numeric input.
+ *
+ * This function returns a parser suitable for use with Commander's .option() method.
+ * If validation fails, it prints an error message and exits with code 1.
+ *
+ * @param optionName - Name of the option for error messages (e.g., "timeout")
+ * @param constraint - Constraint configuration or predefined constraint name
+ * @returns Parser function for Commander options
+ *
+ * @example
+ * ```ts
+ * program
+ *   .option('-t, --timeout <minutes>', 'Task timeout', createNumericParser('timeout', 'timeout'))
+ *   .option('-i, --interval <ms>', 'Refresh interval', createNumericParser('interval', 'interval'))
+ * ```
+ */
+export function createNumericParser(
+  optionName: string,
+  constraint: NumericConstraint | ConstraintName
+): (value: string) => number {
+  return (value: string): number => {
+    const result = validateNumeric(value, optionName, constraint);
+
+    if (!result.valid) {
+      console.error(`${colors.red}Error: ${result.error}${colors.reset}`);
+      process.exit(1);
+    }
+
+    return result.value!;
+  };
+}
+
+/**
+ * Validates multiple numeric options at once.
+ * Useful for validating options after parsing when custom logic is needed.
+ *
+ * @param options - Object containing option values to validate
+ * @param constraints - Map of option names to their constraints
+ * @returns Object with validation results for each option
+ */
+export function validateNumericOptions(
+  options: Record<string, number | undefined>,
+  constraints: Record<string, NumericConstraint | ConstraintName>
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  for (const [name, constraint] of Object.entries(constraints)) {
+    const value = options[name];
+    if (value === undefined) continue;
+
+    const result = validateNumeric(String(value), name, constraint);
+    if (!result.valid && result.error) {
+      errors.push(result.error);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Formats constraint bounds for help text.
+ *
+ * @param constraint - Constraint configuration or predefined constraint name
+ * @returns Human-readable bounds description
+ */
+export function formatConstraintBounds(
+  constraint: NumericConstraint | ConstraintName
+): string {
+  const config: NumericConstraint =
+    typeof constraint === 'string'
+      ? NUMERIC_CONSTRAINTS[constraint]
+      : constraint;
+
+  const parts: string[] = [];
+
+  if (config.integer) {
+    parts.push('integer');
+  }
+
+  if (config.min !== undefined && config.max !== undefined) {
+    parts.push(`${config.min}-${config.max}`);
+  } else if (config.min !== undefined) {
+    parts.push(`>= ${config.min}`);
+  } else if (config.max !== undefined) {
+    parts.push(`<= ${config.max}`);
+  }
+
+  return parts.join(', ');
+}


### PR DESCRIPTION
## Summary
- Add validation utility module (`src/utils/validation.ts`) with predefined constraint sets for common CLI options
- Implement `validateNumeric()` function for validating string inputs against constraints with helpful error messages
- Implement `createNumericParser()` for Commander option parsers that exit with code 1 on validation failure
- Update all numeric CLI options to use validated parsers:
  - `--timeout`: >= 0 (0 = disabled)
  - `--interval`: >= 100ms (prevents tight loops)
  - `--limit`: > 0 (positive integer)
  - `--days`: 1-36500 (positive integer with upper bound)
  - `--budget`: > 0 (positive float)
  - `--iterations`: > 0 (positive integer)
  - `--pr`/issue numbers: > 0 (positive integer)
  - `--priority`: >= 0 (non-negative integer)
- Add 40 unit tests for the validation module

## Test Plan
- Run `npm test` to verify all 233 tests pass
- Test CLI validation manually:
  - `chadgi start --timeout -5` → Error: "Timeout must be a non-negative integer"
  - `chadgi watch --interval 50` → Error: "Interval must be at least 100ms"
  - `chadgi history --limit 0` → Error: "Limit must be a positive integer"
  - `chadgi cleanup --days 999999` → Error: "Days must be a positive integer (1-36500)"
  - `chadgi estimate --budget 0` → Error: "Budget must be a positive number"
  - `chadgi queue skip abc` → Error: "Invalid issue-number: not a valid integer"
  - `chadgi history --limit 3.5` → Error: "Invalid limit: value must be an integer"

Closes #77

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces strict, reusable numeric validation for CLI options to prevent invalid inputs and improve error messages.
> 
> - New `src/utils/validation.ts` with `NUMERIC_CONSTRAINTS`, `validateNumeric`, `createNumericParser`, `validateNumericOptions`, and `formatConstraintBounds`
> - CLI switches from `parseInt/parseFloat` and manual checks to `createNumericParser`/`validateNumeric` for `--timeout`, `--interval`, `--limit`, `--days`, `--budget`, `--iterations`, `--priority`, `--last`, and PR/issue numbers (`queue skip/promote`, `replay`, `diff`, `approve`, `reject`)
> - Errors now print colored, descriptive messages and exit with code 1 on invalid input
> - Re-exports added in `src/utils/index.ts`
> - Adds thorough tests in `src/__tests__/utils/validation.test.ts` covering parsing, bounds, predefined/custom constraints, formatter, and parser exit behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c791642511dc5b344109939c2ff635d8b4ba1be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->