### PR TITLE
[CHAD] Add atomic file write utilities with crash-safe guarantees

### DIFF
--- a/src/__tests__/utils/fileOps.test.ts
+++ b/src/__tests__/utils/fileOps.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for src/utils/fileOps.ts
+ *
+ * Tests atomic file write utilities for crash-safe file operations.
+ */
+
+import { jest } from '@jest/globals';
+import { vol } from 'memfs';
+
+// Track mock calls and allow custom implementations
+let writeFileSyncImpl: ((path: string, content: string, encoding?: string) => void) | null = null;
+let renameSyncImpl: ((oldPath: string, newPath: string) => void) | null = null;
+let unlinkSyncImpl: ((path: string) => void) | null = null;
+let existsSyncImpl: ((path: string) => boolean) | null = null;
+
+// Mock the fs module
+jest.unstable_mockModule('fs', () => ({
+  writeFileSync: jest.fn((path: string, content: string, encoding?: string) => {
+    if (writeFileSyncImpl) {
+      writeFileSyncImpl(path, content, encoding);
+    } else {
+      // Default implementation using memfs
+      const dir = path.substring(0, path.lastIndexOf('/'));
+      if (dir && !vol.existsSync(dir)) {
+        vol.mkdirSync(dir, { recursive: true });
+      }
+      vol.writeFileSync(path, content);
+    }
+  }),
+  renameSync: jest.fn((oldPath: string, newPath: string) => {
+    if (renameSyncImpl) {
+      renameSyncImpl(oldPath, newPath);
+    } else {
+      // Default implementation using memfs
+      const content = vol.readFileSync(oldPath);
+      vol.writeFileSync(newPath, content);
+      vol.unlinkSync(oldPath);
+    }
+  }),
+  unlinkSync: jest.fn((path: string) => {
+    if (unlinkSyncImpl) {
+      unlinkSyncImpl(path);
+    } else if (vol.existsSync(path)) {
+      vol.unlinkSync(path);
+    }
+  }),
+  existsSync: jest.fn((path: string) => {
+    if (existsSyncImpl) {
+      return existsSyncImpl(path);
+    }
+    return vol.existsSync(path);
+  }),
+}));
+
+// Import after mocking
+const { atomicWriteFile, atomicWriteJson, safeWriteFile, safeWriteJson } = await import('../../utils/fileOps.js');
+const fsMock = await import('fs');
+
+describe('fileOps utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vol.reset();
+    // Reset custom implementations
+    writeFileSyncImpl = null;
+    renameSyncImpl = null;
+    unlinkSyncImpl = null;
+    existsSyncImpl = null;
+  });
+
+  describe('atomicWriteFile', () => {
+    it('should write file content atomically', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      atomicWriteFile('/project/.chadgi/test.txt', 'test content');
+
+      expect(vol.readFileSync('/project/.chadgi/test.txt', 'utf-8')).toBe('test content');
+    });
+
+    it('should use writeFileSync for temp file and renameSync for atomic replace', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      atomicWriteFile('/project/.chadgi/config.json', '{"key": "value"}');
+
+      // Should have written to a temp file first
+      expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/project\/\.chadgi\/\.tmp\.\d+\.\d+\.[a-z0-9]+$/),
+        '{"key": "value"}',
+        'utf-8'
+      );
+
+      // Should have renamed temp to target
+      expect(fsMock.renameSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/project\/\.chadgi\/\.tmp\.\d+\.\d+\.[a-z0-9]+$/),
+        '/project/.chadgi/config.json'
+      );
+    });
+
+    it('should clean up temp file on write error', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      writeFileSyncImpl = () => {
+        throw new Error('Disk full');
+      };
+
+      expect(() => atomicWriteFile('/project/.chadgi/test.txt', 'content')).toThrow('Disk full');
+    });
+
+    it('should clean up temp file on rename error', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      // writeFileSync succeeds but renameSync fails
+      writeFileSyncImpl = (path: string, content: string) => {
+        vol.writeFileSync(path, content);
+      };
+
+      renameSyncImpl = () => {
+        throw new Error('Permission denied');
+      };
+
+      expect(() => atomicWriteFile('/project/.chadgi/test.txt', 'content')).toThrow('Permission denied');
+
+      // unlinkSync should be called to clean up
+      expect(fsMock.unlinkSync).toHaveBeenCalled();
+    });
+
+    it('should not fail if cleanup of temp file fails', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      writeFileSyncImpl = () => {
+        throw new Error('Write failed');
+      };
+
+      existsSyncImpl = () => true;
+
+      unlinkSyncImpl = () => {
+        throw new Error('Cannot delete temp file');
+      };
+
+      // Should throw the original error, not the cleanup error
+      expect(() => atomicWriteFile('/project/.chadgi/test.txt', 'content')).toThrow('Write failed');
+    });
+
+    it('should overwrite existing file atomically', () => {
+      vol.fromJSON({
+        '/project/.chadgi/existing.txt': 'old content',
+      });
+
+      atomicWriteFile('/project/.chadgi/existing.txt', 'new content');
+
+      expect(vol.readFileSync('/project/.chadgi/existing.txt', 'utf-8')).toBe('new content');
+    });
+  });
+
+  describe('atomicWriteJson', () => {
+    it('should write JSON with pretty-printing', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const data = { status: 'running', task: 42 };
+      atomicWriteJson('/project/.chadgi/progress.json', data);
+
+      const expected = JSON.stringify(data, null, 2);
+      expect(vol.readFileSync('/project/.chadgi/progress.json', 'utf-8')).toBe(expected);
+    });
+
+    it('should handle complex nested objects', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const data = {
+        status: 'in_progress',
+        current_task: {
+          id: '42',
+          title: 'Test task',
+          branch: 'feature/test',
+        },
+        session: {
+          started_at: '2026-01-15T10:00:00Z',
+          tasks_completed: 5,
+        },
+      };
+
+      atomicWriteJson('/project/.chadgi/progress.json', data);
+
+      const result = JSON.parse(vol.readFileSync('/project/.chadgi/progress.json', 'utf-8') as string);
+      expect(result).toEqual(data);
+    });
+
+    it('should handle arrays', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const data = [
+        { issue: 1, status: 'completed' },
+        { issue: 2, status: 'failed' },
+      ];
+
+      atomicWriteJson('/project/.chadgi/tasks.json', data);
+
+      const result = JSON.parse(vol.readFileSync('/project/.chadgi/tasks.json', 'utf-8') as string);
+      expect(result).toEqual(data);
+    });
+
+    it('should handle null and primitive values', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      atomicWriteJson('/project/.chadgi/null.json', null);
+      expect(vol.readFileSync('/project/.chadgi/null.json', 'utf-8')).toBe('null');
+
+      atomicWriteJson('/project/.chadgi/string.json', 'test');
+      expect(vol.readFileSync('/project/.chadgi/string.json', 'utf-8')).toBe('"test"');
+
+      atomicWriteJson('/project/.chadgi/number.json', 42);
+      expect(vol.readFileSync('/project/.chadgi/number.json', 'utf-8')).toBe('42');
+    });
+  });
+
+  describe('safeWriteFile', () => {
+    it('should write file successfully on first attempt', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      await safeWriteFile('/project/.chadgi/test.txt', 'content');
+
+      expect(vol.readFileSync('/project/.chadgi/test.txt', 'utf-8')).toBe('content');
+      expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry on transient EBUSY error', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      let attempts = 0;
+      writeFileSyncImpl = (path: string, content: string) => {
+        attempts++;
+        if (attempts < 2) {
+          const error = new Error('Resource busy') as NodeJS.ErrnoException;
+          error.code = 'EBUSY';
+          throw error;
+        }
+        vol.writeFileSync(path, content);
+      };
+
+      await safeWriteFile('/project/.chadgi/test.txt', 'content', { retryDelayMs: 10 });
+
+      expect(attempts).toBe(2);
+      expect(vol.readFileSync('/project/.chadgi/test.txt', 'utf-8')).toBe('content');
+    });
+
+    it('should retry on transient EAGAIN error', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      let attempts = 0;
+      writeFileSyncImpl = (path: string, content: string) => {
+        attempts++;
+        if (attempts < 3) {
+          const error = new Error('Try again') as NodeJS.ErrnoException;
+          error.code = 'EAGAIN';
+          throw error;
+        }
+        vol.writeFileSync(path, content);
+      };
+
+      await safeWriteFile('/project/.chadgi/test.txt', 'content', { maxRetries: 5, retryDelayMs: 10 });
+
+      expect(attempts).toBe(3);
+    });
+
+    it('should fail immediately on non-transient errors', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      writeFileSyncImpl = () => {
+        const error = new Error('Permission denied') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        throw error;
+      };
+
+      await expect(safeWriteFile('/project/.chadgi/test.txt', 'content')).rejects.toThrow('Permission denied');
+      expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fail after max retries exceeded', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      writeFileSyncImpl = () => {
+        const error = new Error('Resource busy') as NodeJS.ErrnoException;
+        error.code = 'EBUSY';
+        throw error;
+      };
+
+      await expect(
+        safeWriteFile('/project/.chadgi/test.txt', 'content', { maxRetries: 2, retryDelayMs: 10 })
+      ).rejects.toThrow('Resource busy');
+
+      expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use default retry options', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      writeFileSyncImpl = () => {
+        const error = new Error('Resource busy') as NodeJS.ErrnoException;
+        error.code = 'EBUSY';
+        throw error;
+      };
+
+      await expect(safeWriteFile('/project/.chadgi/test.txt', 'content')).rejects.toThrow();
+
+      // Default is 3 retries
+      expect(fsMock.writeFileSync).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('safeWriteJson', () => {
+    it('should write JSON safely with retries', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const data = { status: 'running', iteration: 3 };
+      await safeWriteJson('/project/.chadgi/progress.json', data);
+
+      const result = JSON.parse(vol.readFileSync('/project/.chadgi/progress.json', 'utf-8') as string);
+      expect(result).toEqual(data);
+    });
+
+    it('should retry on transient error and succeed', async () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      let attempts = 0;
+      writeFileSyncImpl = (path: string, content: string) => {
+        attempts++;
+        if (attempts === 1) {
+          const error = new Error('Resource busy') as NodeJS.ErrnoException;
+          error.code = 'EBUSY';
+          throw error;
+        }
+        vol.writeFileSync(path, content);
+      };
+
+      await safeWriteJson('/project/.chadgi/config.json', { key: 'value' }, { retryDelayMs: 10 });
+
+      expect(attempts).toBe(2);
+    });
+  });
+});

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, readdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { colors } from './utils/colors.js';
+import { atomicWriteJson } from './utils/fileOps.js';
 
 // Import shared types
 import type {
@@ -101,7 +102,7 @@ function logApprovalToHistory(
     }
 
     progress.last_updated = toISOString(new Date());
-    writeFileSync(progressFile, JSON.stringify(progress, null, 2));
+    atomicWriteJson(progressFile, progress);
   } catch {
     // Non-critical, ignore errors
   }
@@ -174,7 +175,7 @@ export async function approve(options: ApproveOptions = {}): Promise<void> {
     lockData.comment = options.message;
   }
 
-  writeFileSync(lockFile, JSON.stringify(lockData, null, 2));
+  atomicWriteJson(lockFile, lockData);
 
   // Log to history
   logApprovalToHistory(chadgiDir, lockData.issue_number, lockData.phase, 'approved', options.message);
@@ -277,7 +278,7 @@ export async function reject(options: RejectOptions = {}): Promise<void> {
     lockData.feedback = options.message;
   }
 
-  writeFileSync(lockFile, JSON.stringify(lockData, null, 2));
+  atomicWriteJson(lockFile, lockData);
 
   // Log to history
   logApprovalToHistory(chadgiDir, lockData.issue_number, lockData.phase, 'rejected', options.message);
@@ -390,7 +391,7 @@ export function createApprovalLock(
   };
 
   const lockFile = join(chadgiDir, `approval-${phase}-${issueNumber}.lock`);
-  writeFileSync(lockFile, JSON.stringify(lockData, null, 2));
+  atomicWriteJson(lockFile, lockData);
 
   return lockFile;
 }

--- a/src/pause.ts
+++ b/src/pause.ts
@@ -1,6 +1,7 @@
-import { existsSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { colors } from './utils/colors.js';
+import { atomicWriteJson } from './utils/fileOps.js';
 
 // Import shared types
 import type { BaseCommandOptions, ProgressData, PauseLockData } from './types/index.js';
@@ -91,7 +92,7 @@ export async function pause(options: PauseOptions = {}): Promise<void> {
     }
   }
 
-  writeFileSync(pauseLockFile, JSON.stringify(pauseData, null, 2));
+  atomicWriteJson(pauseLockFile, pauseData);
 
   console.log(`${colors.yellow}${colors.bold}`);
   console.log('==========================================================');

--- a/src/utils/fileOps.ts
+++ b/src/utils/fileOps.ts
@@ -1,0 +1,204 @@
+/**
+ * Atomic file write utilities for ChadGI.
+ *
+ * Provides crash-safe file writing operations using the write-to-temp-then-rename
+ * pattern. This ensures that files are never left in a corrupted or partial state
+ * even if the process is killed during a write operation.
+ */
+
+import { writeFileSync, renameSync, unlinkSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+
+/**
+ * Default number of retry attempts for transient failures
+ */
+const DEFAULT_MAX_RETRIES = 3;
+
+/**
+ * Default delay between retry attempts in milliseconds
+ */
+const DEFAULT_RETRY_DELAY_MS = 100;
+
+/**
+ * Options for safeWriteFile
+ */
+export interface SafeWriteOptions {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries?: number;
+  /** Delay between retries in milliseconds (default: 100) */
+  retryDelayMs?: number;
+}
+
+/**
+ * Generate a unique temporary file path in the same directory as the target.
+ * Using the same directory ensures atomic rename will work (same filesystem).
+ *
+ * @param filePath - The target file path
+ * @returns A unique temporary file path
+ */
+function getTempPath(filePath: string): string {
+  const dir = dirname(filePath);
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 8);
+  return join(dir, `.tmp.${process.pid}.${timestamp}.${random}`);
+}
+
+/**
+ * Sleep for a specified number of milliseconds
+ *
+ * @param ms - Milliseconds to sleep
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Check if an error is a transient error that can be retried
+ *
+ * @param error - The error to check
+ * @returns true if the error is transient
+ */
+function isTransientError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // EBUSY: resource busy, EAGAIN: try again, EMFILE: too many open files
+    return code === 'EBUSY' || code === 'EAGAIN' || code === 'EMFILE';
+  }
+  return false;
+}
+
+/**
+ * Atomically write content to a file using the write-to-temp-then-rename pattern.
+ *
+ * This ensures that the target file is never left in a corrupted state:
+ * 1. Write content to a temporary file in the same directory
+ * 2. Atomically rename the temp file to the target path
+ * 3. Clean up temp file on failure
+ *
+ * @param filePath - The target file path (must be absolute)
+ * @param content - The content to write
+ * @throws Error if the write fails after cleanup
+ *
+ * @example
+ * ```typescript
+ * atomicWriteFile('/path/to/config.json', JSON.stringify(data));
+ * ```
+ */
+export function atomicWriteFile(filePath: string, content: string): void {
+  const tempPath = getTempPath(filePath);
+
+  try {
+    // Write to temporary file
+    writeFileSync(tempPath, content, 'utf-8');
+
+    // Atomically rename to target (this is atomic on POSIX systems)
+    renameSync(tempPath, filePath);
+  } catch (error) {
+    // Clean up temp file if it exists
+    try {
+      if (existsSync(tempPath)) {
+        unlinkSync(tempPath);
+      }
+    } catch {
+      // Ignore cleanup errors - the original error is more important
+    }
+
+    // Re-throw the original error
+    throw error;
+  }
+}
+
+/**
+ * Atomically write JSON data to a file with pretty-printing.
+ *
+ * This is a convenience wrapper around atomicWriteFile that handles JSON
+ * serialization with proper formatting (2-space indentation).
+ *
+ * @param filePath - The target file path (must be absolute)
+ * @param data - The data to serialize and write
+ * @throws Error if serialization or write fails
+ *
+ * @example
+ * ```typescript
+ * atomicWriteJson('/path/to/progress.json', { status: 'running', task: 42 });
+ * ```
+ */
+export function atomicWriteJson(filePath: string, data: unknown): void {
+  const content = JSON.stringify(data, null, 2);
+  atomicWriteFile(filePath, content);
+}
+
+/**
+ * Safely write content to a file with automatic retry on transient failures.
+ *
+ * This function uses atomicWriteFile internally and adds retry logic for
+ * handling transient filesystem errors like EBUSY (resource busy) or
+ * EAGAIN (try again).
+ *
+ * @param filePath - The target file path (must be absolute)
+ * @param content - The content to write
+ * @param options - Optional retry configuration
+ * @returns Promise that resolves when write succeeds
+ * @throws Error if all retry attempts fail
+ *
+ * @example
+ * ```typescript
+ * await safeWriteFile('/path/to/file.txt', 'content', { maxRetries: 5 });
+ * ```
+ */
+export async function safeWriteFile(
+  filePath: string,
+  content: string,
+  options: SafeWriteOptions = {}
+): Promise<void> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      atomicWriteFile(filePath, content);
+      return; // Success!
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      // Only retry on transient errors
+      if (!isTransientError(error) || attempt === maxRetries) {
+        throw lastError;
+      }
+
+      // Wait before retrying
+      await sleep(retryDelayMs * attempt); // Exponential backoff
+    }
+  }
+
+  // This should never be reached due to the throw above, but TypeScript needs it
+  throw lastError ?? new Error('Unknown error during file write');
+}
+
+/**
+ * Safely write JSON data to a file with automatic retry on transient failures.
+ *
+ * This is a convenience wrapper around safeWriteFile that handles JSON
+ * serialization with proper formatting.
+ *
+ * @param filePath - The target file path (must be absolute)
+ * @param data - The data to serialize and write
+ * @param options - Optional retry configuration
+ * @returns Promise that resolves when write succeeds
+ * @throws Error if all retry attempts fail
+ *
+ * @example
+ * ```typescript
+ * await safeWriteJson('/path/to/config.json', { key: 'value' });
+ * ```
+ */
+export async function safeWriteJson(
+  filePath: string,
+  data: unknown,
+  options: SafeWriteOptions = {}
+): Promise<void> {
+  const content = JSON.stringify(data, null, 2);
+  await safeWriteFile(filePath, content, options);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -151,3 +151,12 @@ export {
   type ConstraintName,
   type ValidationResult,
 } from './validation.js';
+
+// File Operations (atomic writes)
+export {
+  atomicWriteFile,
+  atomicWriteJson,
+  safeWriteFile,
+  safeWriteJson,
+  type SafeWriteOptions,
+} from './fileOps.js';


### PR DESCRIPTION
## Summary
- Add new `src/utils/fileOps.ts` with atomic file write utilities
- `atomicWriteFile()` - atomic text file write using temp + rename pattern
- `atomicWriteJson()` - atomic JSON write with pretty-printing (2-space indent)
- `safeWriteFile()` / `safeWriteJson()` - atomic writes with retry logic for transient failures (EBUSY, EAGAIN, EMFILE)
- Update `pause.ts` to use `atomicWriteJson` for pause.lock files
- Update `approve.ts` to use `atomicWriteJson` for approval locks and progress files
- Update `snapshot.ts` to use `atomicWriteJson`/`atomicWriteFile` for snapshot and config files
- Export new utilities from `utils/index.ts`
- Add 18 comprehensive unit tests for all atomic write functionality

## Test Plan
- [x] Run `npm run build` - TypeScript compiles without errors
- [x] Run `npm run test:unit` - All 330 tests pass (including 18 new fileOps tests)
- [x] Verify atomic write pattern: temp file created in same directory, renamed to target
- [x] Verify error handling: temp files cleaned up on failure
- [x] Verify retry logic: transient errors (EBUSY, EAGAIN) trigger retries with exponential backoff

Closes #83

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces crash-safe atomic file writes and applies them to critical paths.
> 
> - **New:** `src/utils/fileOps.ts` with `atomicWriteFile`, `atomicWriteJson`, `safeWriteFile`, `safeWriteJson` (temp+rename, cleanup, transient error retries with backoff)
> - **Integration:** Replace direct `writeFileSync` with atomic writes in `approve.ts` (locks, `chadgi-progress.json`), `pause.ts` (`pause.lock`), and `snapshot.ts` (snapshot save, config/templates restore)
> - **Tests:** Add `__tests__/utils/fileOps.test.ts` covering atomic pattern, cleanup, JSON handling, and retry logic
> - **Exports:** Re-export new utilities from `utils/index.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de386eb6e1fc030f2d1957ae8f08b092a35b3bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->