### PR TITLE
[CHAD] Add task lock mechanism to prevent concurrent processing of same issue

### DIFF
--- a/schemas/chadgi-config.schema.json
+++ b/schemas/chadgi-config.schema.json
@@ -84,6 +84,12 @@
       "default": "depends on blocked by requires",
       "description": "Space-separated phrases that indicate task dependencies. ChadGI looks for these patterns followed by issue numbers in issue body."
     },
+    "task_lock_timeout_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 120,
+      "description": "Timeout in minutes for task locks. Locks older than this are considered stale and can be overridden. Default: 120 (2 hours)."
+    },
     "local_file": {
       "$ref": "#/$defs/LocalFileConfig"
     },

--- a/src/__tests__/utils/data.test.ts
+++ b/src/__tests__/utils/data.test.ts
@@ -13,6 +13,20 @@ jest.unstable_mockModule('fs', () => ({
   existsSync: jest.fn((path: string) => vol.existsSync(path)),
   readFileSync: jest.fn((path: string, encoding?: string) => vol.readFileSync(path, encoding)),
   readdirSync: jest.fn((dir: string) => vol.readdirSync(dir)),
+  mkdirSync: jest.fn((path: string, options?: object) => vol.mkdirSync(path, options)),
+  unlinkSync: jest.fn((path: string) => vol.unlinkSync(path)),
+  writeFileSync: jest.fn((path: string, content: string, encoding?: string) => {
+    const dir = path.substring(0, path.lastIndexOf('/'));
+    if (dir && !vol.existsSync(dir)) {
+      vol.mkdirSync(dir, { recursive: true });
+    }
+    vol.writeFileSync(path, content);
+  }),
+  renameSync: jest.fn((oldPath: string, newPath: string) => {
+    const content = vol.readFileSync(oldPath);
+    vol.writeFileSync(newPath, content);
+    vol.unlinkSync(oldPath);
+  }),
 }));
 
 // Import after mocking

--- a/src/__tests__/utils/locks.test.ts
+++ b/src/__tests__/utils/locks.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Unit tests for src/utils/locks.ts
+ *
+ * Tests task lock utilities for preventing concurrent processing of same issue.
+ */
+
+import { jest } from '@jest/globals';
+import { vol } from 'memfs';
+
+// Mock the fs module
+jest.unstable_mockModule('fs', () => ({
+  existsSync: jest.fn((path: string) => vol.existsSync(path)),
+  readFileSync: jest.fn((path: string, encoding?: string) => vol.readFileSync(path, encoding)),
+  readdirSync: jest.fn((dir: string) => vol.readdirSync(dir)),
+  mkdirSync: jest.fn((path: string, options?: object) => vol.mkdirSync(path, options)),
+  unlinkSync: jest.fn((path: string) => vol.unlinkSync(path)),
+  writeFileSync: jest.fn((path: string, content: string, encoding?: string) => {
+    const dir = path.substring(0, path.lastIndexOf('/'));
+    if (dir && !vol.existsSync(dir)) {
+      vol.mkdirSync(dir, { recursive: true });
+    }
+    vol.writeFileSync(path, content);
+  }),
+  renameSync: jest.fn((oldPath: string, newPath: string) => {
+    const content = vol.readFileSync(oldPath);
+    vol.writeFileSync(newPath, content);
+    vol.unlinkSync(oldPath);
+  }),
+}));
+
+// Mock os.hostname
+jest.unstable_mockModule('os', () => ({
+  hostname: jest.fn(() => 'test-host'),
+}));
+
+// Import after mocking
+const {
+  generateSessionId,
+  getLocksDir,
+  getLockFilePath,
+  ensureLocksDir,
+  readTaskLock,
+  isLockStale,
+  acquireTaskLock,
+  releaseTaskLock,
+  forceReleaseTaskLock,
+  updateLockHeartbeat,
+  listTaskLocks,
+  findStaleLocks,
+  cleanupStaleLocks,
+  isIssueLocked,
+  isLockedByOther,
+  releaseAllSessionLocks,
+  DEFAULT_LOCK_TIMEOUT_MINUTES,
+} = await import('../../utils/locks.js');
+
+describe('locks utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vol.reset();
+  });
+
+  describe('generateSessionId', () => {
+    it('should generate a unique session ID', () => {
+      const id1 = generateSessionId();
+      const id2 = generateSessionId();
+
+      expect(id1).toBeTruthy();
+      expect(id2).toBeTruthy();
+      expect(id1).not.toBe(id2);
+      expect(id1).toContain('test-host');
+    });
+  });
+
+  describe('getLocksDir', () => {
+    it('should return the locks directory path', () => {
+      const result = getLocksDir('/project/.chadgi');
+      expect(result).toBe('/project/.chadgi/locks');
+    });
+  });
+
+  describe('getLockFilePath', () => {
+    it('should return the lock file path for an issue', () => {
+      const result = getLockFilePath('/project/.chadgi', 42);
+      expect(result).toBe('/project/.chadgi/locks/issue-42.lock');
+    });
+  });
+
+  describe('ensureLocksDir', () => {
+    it('should create the locks directory if it does not exist', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      ensureLocksDir('/project/.chadgi');
+
+      expect(vol.existsSync('/project/.chadgi/locks')).toBe(true);
+    });
+
+    it('should not fail if directory already exists', () => {
+      vol.mkdirSync('/project/.chadgi/locks', { recursive: true });
+
+      expect(() => ensureLocksDir('/project/.chadgi')).not.toThrow();
+    });
+  });
+
+  describe('readTaskLock', () => {
+    it('should return null if no lock exists', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const result = readTaskLock('/project/.chadgi', 42);
+      expect(result).toBeNull();
+    });
+
+    it('should read and parse lock file', () => {
+      const lockData = {
+        issue_number: 42,
+        session_id: 'session-123',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: '2026-01-15T10:00:00Z',
+        last_heartbeat: '2026-01-15T10:05:00Z',
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lockData),
+      });
+
+      const result = readTaskLock('/project/.chadgi', 42);
+      expect(result).not.toBeNull();
+      expect(result?.issue_number).toBe(42);
+      expect(result?.session_id).toBe('session-123');
+    });
+
+    it('should return null on invalid JSON', () => {
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': 'invalid json',
+      });
+
+      const result = readTaskLock('/project/.chadgi', 42);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isLockStale', () => {
+    it('should return false for recent lock', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-123',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      const result = isLockStale(lock);
+      expect(result).toBe(false);
+    });
+
+    it('should return true for old lock', () => {
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(); // 3 hours ago
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-123',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+      };
+
+      const result = isLockStale(lock, 120); // 2 hour timeout
+      expect(result).toBe(true);
+    });
+
+    it('should respect custom timeout', () => {
+      const recentTime = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30 minutes ago
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-123',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      // Should not be stale with 2 hour timeout
+      expect(isLockStale(lock, 120)).toBe(false);
+
+      // Should be stale with 20 minute timeout
+      expect(isLockStale(lock, 20)).toBe(true);
+    });
+  });
+
+  describe('acquireTaskLock', () => {
+    it('should acquire lock when no existing lock', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const result = acquireTaskLock('/project/.chadgi', 42, 'session-abc');
+
+      expect(result.acquired).toBe(true);
+      expect(result.lock).toBeDefined();
+      expect(result.lock?.issue_number).toBe(42);
+      expect(result.lock?.session_id).toBe('session-abc');
+    });
+
+    it('should refresh lock if same session owns it', () => {
+      const existingLock = {
+        issue_number: 42,
+        session_id: 'session-abc',
+        pid: process.pid,
+        hostname: 'test-host',
+        locked_at: '2026-01-15T10:00:00Z',
+        last_heartbeat: '2026-01-15T10:00:00Z',
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(existingLock),
+      });
+
+      const result = acquireTaskLock('/project/.chadgi', 42, 'session-abc');
+
+      expect(result.acquired).toBe(true);
+      // Heartbeat should be updated
+      expect(new Date(result.lock!.last_heartbeat).getTime()).toBeGreaterThan(
+        new Date('2026-01-15T10:00:00Z').getTime()
+      );
+    });
+
+    it('should fail if lock is held by another active session', () => {
+      const existingLock = {
+        issue_number: 42,
+        session_id: 'other-session',
+        pid: 99999, // Different process
+        hostname: 'other-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(existingLock),
+      });
+
+      const result = acquireTaskLock('/project/.chadgi', 42, 'session-abc');
+
+      expect(result.acquired).toBe(false);
+      expect(result.reason).toBe('already_locked');
+    });
+
+    it('should acquire lock with forceClaim on stale lock', () => {
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(); // 3 hours ago
+      const existingLock = {
+        issue_number: 42,
+        session_id: 'stale-session',
+        pid: 99999,
+        hostname: 'other-host',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(existingLock),
+      });
+
+      const result = acquireTaskLock('/project/.chadgi', 42, 'session-abc', { forceClaim: true });
+
+      expect(result.acquired).toBe(true);
+      expect(result.lock?.session_id).toBe('session-abc');
+    });
+
+    it('should include worker_id and repo_name when provided', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const result = acquireTaskLock('/project/.chadgi', 42, 'session-abc', {
+        workerId: 3,
+        repoName: 'test-repo',
+      });
+
+      expect(result.acquired).toBe(true);
+      expect(result.lock?.worker_id).toBe(3);
+      expect(result.lock?.repo_name).toBe('test-repo');
+    });
+  });
+
+  describe('releaseTaskLock', () => {
+    it('should return true if no lock exists', () => {
+      vol.mkdirSync('/project/.chadgi/locks', { recursive: true });
+
+      const result = releaseTaskLock('/project/.chadgi', 42);
+      expect(result).toBe(true);
+    });
+
+    it('should release lock owned by session', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-abc',
+        pid: process.pid,
+        hostname: 'test-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = releaseTaskLock('/project/.chadgi', 42, 'session-abc');
+
+      expect(result).toBe(true);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-42.lock')).toBe(false);
+    });
+
+    it('should not release lock owned by another session', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'other-session',
+        pid: 99999,
+        hostname: 'other-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = releaseTaskLock('/project/.chadgi', 42, 'session-abc');
+
+      expect(result).toBe(false);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-42.lock')).toBe(true);
+    });
+  });
+
+  describe('forceReleaseTaskLock', () => {
+    it('should force release lock regardless of owner', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'other-session',
+        pid: 99999,
+        hostname: 'other-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = forceReleaseTaskLock('/project/.chadgi', 42);
+
+      expect(result).toBe(true);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-42.lock')).toBe(false);
+    });
+  });
+
+  describe('listTaskLocks', () => {
+    it('should return empty array when no locks', () => {
+      vol.mkdirSync('/project/.chadgi', { recursive: true });
+
+      const result = listTaskLocks('/project/.chadgi');
+      expect(result).toEqual([]);
+    });
+
+    it('should list all locks with status info', () => {
+      const recentTime = new Date().toISOString();
+      const lock1 = {
+        issue_number: 42,
+        session_id: 'session-1',
+        pid: 1234,
+        hostname: 'host-1',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      const lock2 = {
+        issue_number: 43,
+        session_id: 'session-2',
+        pid: 5678,
+        hostname: 'host-2',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+        worker_id: 2,
+        repo_name: 'test-repo',
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock1),
+        '/project/.chadgi/locks/issue-43.lock': JSON.stringify(lock2),
+      });
+
+      const result = listTaskLocks('/project/.chadgi');
+
+      expect(result).toHaveLength(2);
+
+      const lock42 = result.find(l => l.issueNumber === 42);
+      expect(lock42?.isStale).toBe(false);
+
+      const lock43 = result.find(l => l.issueNumber === 43);
+      expect(lock43?.isStale).toBe(true);
+      expect(lock43?.workerId).toBe(2);
+      expect(lock43?.repoName).toBe('test-repo');
+    });
+  });
+
+  describe('findStaleLocks', () => {
+    it('should return only stale locks', () => {
+      const recentTime = new Date().toISOString();
+      const lock1 = {
+        issue_number: 42,
+        session_id: 'session-1',
+        pid: 1234,
+        hostname: 'host-1',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      const lock2 = {
+        issue_number: 43,
+        session_id: 'session-2',
+        pid: 5678,
+        hostname: 'host-2',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock1),
+        '/project/.chadgi/locks/issue-43.lock': JSON.stringify(lock2),
+      });
+
+      const result = findStaleLocks('/project/.chadgi');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].issueNumber).toBe(43);
+    });
+  });
+
+  describe('cleanupStaleLocks', () => {
+    it('should remove stale locks', () => {
+      const recentTime = new Date().toISOString();
+      const lock1 = {
+        issue_number: 42,
+        session_id: 'session-1',
+        pid: 1234,
+        hostname: 'host-1',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      const lock2 = {
+        issue_number: 43,
+        session_id: 'session-2',
+        pid: 5678,
+        hostname: 'host-2',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock1),
+        '/project/.chadgi/locks/issue-43.lock': JSON.stringify(lock2),
+      });
+
+      const removedCount = cleanupStaleLocks('/project/.chadgi');
+
+      expect(removedCount).toBe(1);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-42.lock')).toBe(true);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-43.lock')).toBe(false);
+    });
+  });
+
+  describe('isIssueLocked', () => {
+    it('should return true when lock exists', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-1',
+        pid: 1234,
+        hostname: 'host-1',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      expect(isIssueLocked('/project/.chadgi', 42)).toBe(true);
+    });
+
+    it('should return false when no lock exists', () => {
+      vol.mkdirSync('/project/.chadgi/locks', { recursive: true });
+
+      expect(isIssueLocked('/project/.chadgi', 42)).toBe(false);
+    });
+  });
+
+  describe('isLockedByOther', () => {
+    it('should return false when not locked', () => {
+      vol.mkdirSync('/project/.chadgi/locks', { recursive: true });
+
+      const result = isLockedByOther('/project/.chadgi', 42, 'session-abc');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when locked by same session', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'session-abc',
+        pid: process.pid,
+        hostname: 'test-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = isLockedByOther('/project/.chadgi', 42, 'session-abc');
+      expect(result).toBe(false);
+    });
+
+    it('should return true when locked by another active session', () => {
+      const lock = {
+        issue_number: 42,
+        session_id: 'other-session',
+        pid: 99999,
+        hostname: 'other-host',
+        locked_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = isLockedByOther('/project/.chadgi', 42, 'session-abc');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when lock is stale', () => {
+      const oldTime = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      const lock = {
+        issue_number: 42,
+        session_id: 'other-session',
+        pid: 99999,
+        hostname: 'other-host',
+        locked_at: oldTime,
+        last_heartbeat: oldTime,
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock),
+      });
+
+      const result = isLockedByOther('/project/.chadgi', 42, 'session-abc');
+      expect(result).toBe(false); // Stale locks don't block
+    });
+  });
+
+  describe('releaseAllSessionLocks', () => {
+    it('should release all locks for a session', () => {
+      const recentTime = new Date().toISOString();
+      const lock1 = {
+        issue_number: 42,
+        session_id: 'session-abc',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      const lock2 = {
+        issue_number: 43,
+        session_id: 'session-abc',
+        pid: 1234,
+        hostname: 'test-host',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      const lock3 = {
+        issue_number: 44,
+        session_id: 'other-session',
+        pid: 5678,
+        hostname: 'other-host',
+        locked_at: recentTime,
+        last_heartbeat: recentTime,
+      };
+
+      vol.fromJSON({
+        '/project/.chadgi/locks/issue-42.lock': JSON.stringify(lock1),
+        '/project/.chadgi/locks/issue-43.lock': JSON.stringify(lock2),
+        '/project/.chadgi/locks/issue-44.lock': JSON.stringify(lock3),
+      });
+
+      const releasedCount = releaseAllSessionLocks('/project/.chadgi', 'session-abc');
+
+      expect(releasedCount).toBe(2);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-42.lock')).toBe(false);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-43.lock')).toBe(false);
+      expect(vol.existsSync('/project/.chadgi/locks/issue-44.lock')).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_LOCK_TIMEOUT_MINUTES', () => {
+    it('should have correct default value', () => {
+      expect(DEFAULT_LOCK_TIMEOUT_MINUTES).toBe(120);
+    });
+  });
+});

--- a/src/start.ts
+++ b/src/start.ts
@@ -29,6 +29,7 @@ interface StartOptions {
   parallel?: number;
   interactive?: boolean;
   mask?: boolean;  // --no-mask flag sets this to false
+  forceClaim?: boolean;  // --force-claim flag to override stale locks
 }
 
 interface WorkerInfo {
@@ -65,6 +66,7 @@ export async function start(options: StartOptions = {}): Promise<void> {
   const debugMode = options.debug ?? false;
   const ignoreDeps = options.ignoreDeps ?? false;
   const interactiveMode = options.interactive ?? false;
+  const forceClaim = options.forceClaim ?? false;
 
   if (interactiveMode) {
     console.log('Starting ChadGI in INTERACTIVE mode...\n');
@@ -128,7 +130,8 @@ export async function start(options: StartOptions = {}): Promise<void> {
     DEBUG_MODE: debugMode ? 'true' : 'false',
     IGNORE_DEPS: ignoreDeps ? 'true' : 'false',
     INTERACTIVE_MODE: interactiveMode ? 'true' : 'false',
-    NO_MASK: noMask ? 'true' : 'false'
+    NO_MASK: noMask ? 'true' : 'false',
+    FORCE_CLAIM: forceClaim ? 'true' : 'false'
   };
 
   // Add timeout override if specified via CLI
@@ -177,6 +180,7 @@ function runRepoTask(
       IGNORE_DEPS: options.ignoreDeps ? 'true' : 'false',
       INTERACTIVE_MODE: options.interactive ? 'true' : 'false',
       NO_MASK: options.mask === false ? 'true' : 'false',
+      FORCE_CLAIM: options.forceClaim ? 'true' : 'false',
       WORKSPACE_MODE: 'true',
       WORKSPACE_SINGLE_TASK: 'true', // Process only one task then exit
     };
@@ -500,6 +504,7 @@ function runWorkerTask(
       IGNORE_DEPS: options.ignoreDeps ? 'true' : 'false',
       INTERACTIVE_MODE: options.interactive ? 'true' : 'false',
       NO_MASK: options.mask === false ? 'true' : 'false',
+      FORCE_CLAIM: options.forceClaim ? 'true' : 'false',
       WORKSPACE_MODE: 'true',
       WORKSPACE_SINGLE_TASK: 'true',
       PARALLEL_WORKER_ID: String(workerInfo.id),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -660,6 +660,87 @@ export interface UpdateCheckCache {
   current_version: string;
 }
 
+// ============================================================================
+// Task Lock Types
+// ============================================================================
+
+/**
+ * Task lock file data for preventing concurrent processing of same issue.
+ * Lock file format: issue-<number>.lock in .chadgi/locks/ directory
+ */
+export interface TaskLockData {
+  /** Issue number that is locked */
+  issue_number: number;
+  /** Unique session identifier to distinguish lock owners */
+  session_id: string;
+  /** Process ID of the session holding the lock */
+  pid: number;
+  /** Hostname of the machine holding the lock */
+  hostname: string;
+  /** ISO timestamp when the lock was acquired */
+  locked_at: string;
+  /** ISO timestamp of the last heartbeat (updated periodically while active) */
+  last_heartbeat: string;
+  /** Optional worker ID for parallel/workspace mode */
+  worker_id?: number;
+  /** Optional repository name for workspace mode */
+  repo_name?: string;
+}
+
+/**
+ * Result of attempting to acquire a task lock
+ */
+export interface TaskLockResult {
+  /** Whether the lock was successfully acquired */
+  acquired: boolean;
+  /** The lock data if acquired, or existing lock info if not */
+  lock?: TaskLockData;
+  /** Reason for lock acquisition failure */
+  reason?: 'already_locked' | 'stale_lock' | 'error';
+  /** Error message if acquisition failed */
+  error?: string;
+}
+
+/**
+ * Options for acquiring a task lock
+ */
+export interface TaskLockOptions {
+  /** Force acquisition even if lock exists (will check staleness) */
+  forceClaim?: boolean;
+  /** Custom timeout in minutes (overrides config) */
+  timeoutMinutes?: number;
+  /** Worker ID for parallel mode */
+  workerId?: number;
+  /** Repository name for workspace mode */
+  repoName?: string;
+}
+
+/**
+ * Task lock status information for display
+ */
+export interface TaskLockInfo {
+  /** Issue number */
+  issueNumber: number;
+  /** Session ID holding the lock */
+  sessionId: string;
+  /** PID of the locking process */
+  pid: number;
+  /** Hostname of the locking machine */
+  hostname: string;
+  /** When the lock was acquired */
+  lockedAt: string;
+  /** Seconds since lock was acquired */
+  lockedSeconds: number;
+  /** Seconds since last heartbeat */
+  heartbeatAgeSeconds: number;
+  /** Whether this lock is considered stale */
+  isStale: boolean;
+  /** Worker ID if in parallel mode */
+  workerId?: number;
+  /** Repository name if in workspace mode */
+  repoName?: string;
+}
+
 /**
  * Version info for JSON output
  */

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -1,0 +1,301 @@
+/**
+ * Unlock command for ChadGI.
+ *
+ * Manually releases task locks to allow re-processing of issues.
+ */
+
+import { existsSync } from 'fs';
+import { colors } from './utils/colors.js';
+import { resolveConfigPath } from './utils/config.js';
+import { formatDuration } from './utils/formatting.js';
+import {
+  forceReleaseTaskLock,
+  listTaskLocks,
+  findStaleLocks,
+  cleanupStaleLocks,
+  readTaskLock,
+  DEFAULT_LOCK_TIMEOUT_MINUTES,
+} from './utils/locks.js';
+import type { BaseCommandOptions, TaskLockInfo } from './types/index.js';
+
+interface UnlockOptions extends BaseCommandOptions {
+  all?: boolean;
+  stale?: boolean;
+  force?: boolean;
+}
+
+interface UnlockResult {
+  success: boolean;
+  action: 'unlock' | 'list' | 'cleanup';
+  issueNumber?: number;
+  released?: number;
+  locks?: TaskLockInfo[];
+  message: string;
+}
+
+/**
+ * Format a single lock for display
+ */
+function formatLockInfo(lock: TaskLockInfo): string {
+  const lines: string[] = [];
+  const staleIndicator = lock.isStale ? `${colors.yellow}(stale)${colors.reset}` : '';
+
+  lines.push(`  Issue #${lock.issueNumber} ${staleIndicator}`);
+  lines.push(`    Session:   ${lock.sessionId}`);
+  lines.push(`    PID:       ${lock.pid}`);
+  lines.push(`    Hostname:  ${lock.hostname}`);
+  lines.push(`    Locked:    ${formatDuration(lock.lockedSeconds)} ago`);
+  lines.push(`    Heartbeat: ${formatDuration(lock.heartbeatAgeSeconds)} ago`);
+
+  if (lock.workerId !== undefined) {
+    lines.push(`    Worker:    ${lock.workerId}`);
+  }
+  if (lock.repoName) {
+    lines.push(`    Repo:      ${lock.repoName}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * List all current task locks
+ */
+async function listLocks(chadgiDir: string, options: UnlockOptions): Promise<UnlockResult> {
+  const locks = listTaskLocks(chadgiDir);
+
+  if (locks.length === 0) {
+    return {
+      success: true,
+      action: 'list',
+      released: 0,
+      locks: [],
+      message: 'No task locks found.',
+    };
+  }
+
+  const staleLocks = locks.filter((l) => l.isStale);
+  const activeLocks = locks.filter((l) => !l.isStale);
+
+  return {
+    success: true,
+    action: 'list',
+    released: 0,
+    locks,
+    message: `Found ${locks.length} task lock(s): ${activeLocks.length} active, ${staleLocks.length} stale.`,
+  };
+}
+
+/**
+ * Clean up stale locks
+ */
+async function cleanupStale(chadgiDir: string, options: UnlockOptions): Promise<UnlockResult> {
+  const staleLocks = findStaleLocks(chadgiDir);
+
+  if (staleLocks.length === 0) {
+    return {
+      success: true,
+      action: 'cleanup',
+      released: 0,
+      locks: [],
+      message: 'No stale locks found.',
+    };
+  }
+
+  const removedCount = cleanupStaleLocks(chadgiDir);
+
+  return {
+    success: true,
+    action: 'cleanup',
+    released: removedCount,
+    locks: staleLocks,
+    message: `Removed ${removedCount} stale lock(s).`,
+  };
+}
+
+/**
+ * Unlock a specific issue
+ */
+async function unlockIssue(
+  chadgiDir: string,
+  issueNumber: number,
+  options: UnlockOptions
+): Promise<UnlockResult> {
+  const lock = readTaskLock(chadgiDir, issueNumber);
+
+  if (!lock) {
+    return {
+      success: false,
+      action: 'unlock',
+      issueNumber,
+      message: `Issue #${issueNumber} is not locked.`,
+    };
+  }
+
+  // Check if force is required for non-stale locks
+  const isStale = lock.last_heartbeat
+    ? (Date.now() - new Date(lock.last_heartbeat).getTime()) > DEFAULT_LOCK_TIMEOUT_MINUTES * 60 * 1000
+    : false;
+
+  if (!isStale && !options.force) {
+    return {
+      success: false,
+      action: 'unlock',
+      issueNumber,
+      message: `Issue #${issueNumber} is locked by an active session (${lock.session_id}). Use --force to override.`,
+    };
+  }
+
+  const released = forceReleaseTaskLock(chadgiDir, issueNumber);
+
+  if (released) {
+    return {
+      success: true,
+      action: 'unlock',
+      issueNumber,
+      released: 1,
+      message: `Released lock for issue #${issueNumber}.`,
+    };
+  } else {
+    return {
+      success: false,
+      action: 'unlock',
+      issueNumber,
+      message: `Failed to release lock for issue #${issueNumber}.`,
+    };
+  }
+}
+
+/**
+ * Unlock all locks
+ */
+async function unlockAll(chadgiDir: string, options: UnlockOptions): Promise<UnlockResult> {
+  const locks = listTaskLocks(chadgiDir);
+
+  if (locks.length === 0) {
+    return {
+      success: true,
+      action: 'unlock',
+      released: 0,
+      locks: [],
+      message: 'No locks to release.',
+    };
+  }
+
+  // Without force, only remove stale locks
+  const locksToRemove = options.force ? locks : locks.filter((l) => l.isStale);
+
+  if (locksToRemove.length === 0) {
+    return {
+      success: false,
+      action: 'unlock',
+      released: 0,
+      locks,
+      message: `Found ${locks.length} active lock(s). Use --force to release active locks.`,
+    };
+  }
+
+  let removedCount = 0;
+  for (const lock of locksToRemove) {
+    if (forceReleaseTaskLock(chadgiDir, lock.issueNumber)) {
+      removedCount++;
+    }
+  }
+
+  return {
+    success: true,
+    action: 'unlock',
+    released: removedCount,
+    locks: locksToRemove,
+    message: `Released ${removedCount} lock(s).`,
+  };
+}
+
+/**
+ * Print unlock results
+ */
+function printResult(result: UnlockResult, showLocks: boolean): void {
+  if (result.action === 'list' && result.locks && result.locks.length > 0) {
+    console.log(`${colors.purple}${colors.bold}`);
+    console.log('==========================================================');
+    console.log('                    TASK LOCKS                            ');
+    console.log('==========================================================');
+    console.log(`${colors.reset}`);
+
+    const activeLocks = result.locks.filter((l) => !l.isStale);
+    const staleLocks = result.locks.filter((l) => l.isStale);
+
+    if (activeLocks.length > 0) {
+      console.log(`${colors.cyan}${colors.bold}Active Locks (${activeLocks.length})${colors.reset}`);
+      for (const lock of activeLocks) {
+        console.log(formatLockInfo(lock));
+      }
+      console.log('');
+    }
+
+    if (staleLocks.length > 0) {
+      console.log(`${colors.yellow}${colors.bold}Stale Locks (${staleLocks.length})${colors.reset}`);
+      for (const lock of staleLocks) {
+        console.log(formatLockInfo(lock));
+      }
+      console.log('');
+      console.log(`${colors.dim}Run 'chadgi unlock --stale' to clean up stale locks.${colors.reset}`);
+    }
+  } else if (showLocks && result.locks && result.locks.length > 0) {
+    console.log('');
+    console.log(`${colors.cyan}Released locks:${colors.reset}`);
+    for (const lock of result.locks) {
+      console.log(`  - Issue #${lock.issueNumber}`);
+    }
+  }
+
+  // Print message
+  const color = result.success ? colors.green : colors.red;
+  console.log(`${color}${result.message}${colors.reset}`);
+}
+
+/**
+ * Main unlock command
+ */
+export async function unlock(
+  issueNumber?: number,
+  options: UnlockOptions = {}
+): Promise<void> {
+  const cwd = process.cwd();
+  const { chadgiDir } = resolveConfigPath(options.config, cwd);
+
+  if (!existsSync(chadgiDir)) {
+    if (options.json) {
+      console.log(JSON.stringify({ success: false, error: '.chadgi directory not found' }, null, 2));
+    } else {
+      console.error(`${colors.red}Error: .chadgi directory not found.${colors.reset}`);
+      console.error('Run `chadgi init` first to initialize ChadGI.');
+    }
+    process.exit(1);
+  }
+
+  let result: UnlockResult;
+
+  if (options.stale) {
+    // Clean up stale locks only
+    result = await cleanupStale(chadgiDir, options);
+  } else if (options.all) {
+    // Unlock all locks (with force) or all stale locks (without force)
+    result = await unlockAll(chadgiDir, options);
+  } else if (issueNumber !== undefined) {
+    // Unlock specific issue
+    result = await unlockIssue(chadgiDir, issueNumber, options);
+  } else {
+    // No issue specified - list locks
+    result = await listLocks(chadgiDir, options);
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printResult(result, result.action !== 'list');
+  }
+
+  if (!result.success) {
+    process.exit(1);
+  }
+}

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -14,7 +14,16 @@ import type {
   ProgressData,
   PauseLockData,
   ApprovalLockData,
+  TaskLockData,
+  TaskLockInfo,
 } from '../types/index.js';
+import {
+  readTaskLock,
+  listTaskLocks,
+  findStaleLocks,
+  isLockStale,
+  DEFAULT_LOCK_TIMEOUT_MINUTES,
+} from './locks.js';
 
 // ============================================================================
 // Session Stats
@@ -232,6 +241,63 @@ export function listApprovalLocks(chadgiDir: string): ApprovalLockData[] {
     // Directory read error
   }
   return approvals;
+}
+
+// ============================================================================
+// Task Locks
+// ============================================================================
+
+/**
+ * Load a specific task lock
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number
+ * @returns Task lock data or null if no lock exists
+ */
+export function loadTaskLock(chadgiDir: string, issueNumber: number): TaskLockData | null {
+  return readTaskLock(chadgiDir, issueNumber);
+}
+
+/**
+ * Get all current task locks with status information
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param timeoutMinutes - Timeout for staleness determination
+ * @returns Array of task lock info objects
+ */
+export function loadAllTaskLocks(
+  chadgiDir: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): TaskLockInfo[] {
+  return listTaskLocks(chadgiDir, timeoutMinutes);
+}
+
+/**
+ * Get all stale task locks
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param timeoutMinutes - Timeout in minutes for staleness
+ * @returns Array of stale task lock info objects
+ */
+export function loadStaleLocks(
+  chadgiDir: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): TaskLockInfo[] {
+  return findStaleLocks(chadgiDir, timeoutMinutes);
+}
+
+/**
+ * Check if a task lock is stale
+ *
+ * @param lock - The task lock data
+ * @param timeoutMinutes - Timeout in minutes
+ * @returns true if the lock is stale
+ */
+export function isTaskLockStale(
+  lock: TaskLockData,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): boolean {
+  return isLockStale(lock, timeoutMinutes);
 }
 
 // ============================================================================

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -123,6 +123,10 @@ export {
   loadJsonFile,
   fileExists,
   readTextFile,
+  loadTaskLock,
+  loadAllTaskLocks,
+  loadStaleLocks,
+  isTaskLockStale,
 } from './data.js';
 
 // Secrets
@@ -169,3 +173,28 @@ export {
   createSpinner,
   type ProgressBarOptions,
 } from './progress.js';
+
+// Locks (task lock utilities)
+export {
+  DEFAULT_LOCK_TIMEOUT_MINUTES,
+  HEARTBEAT_INTERVAL_MS,
+  LOCKS_DIRECTORY,
+  generateSessionId,
+  getLocksDir,
+  getLockFilePath,
+  ensureLocksDir,
+  readTaskLock,
+  isLockStale,
+  isProcessRunning,
+  acquireTaskLock,
+  releaseTaskLock,
+  forceReleaseTaskLock,
+  updateLockHeartbeat,
+  listTaskLocks,
+  findStaleLocks,
+  cleanupStaleLocks,
+  isIssueLocked,
+  isLockedByOther,
+  startHeartbeat,
+  releaseAllSessionLocks,
+} from './locks.js';

--- a/src/utils/locks.ts
+++ b/src/utils/locks.ts
@@ -1,0 +1,482 @@
+/**
+ * Task lock utilities for ChadGI.
+ *
+ * Provides functions for managing task-level locks to prevent concurrent
+ * processing of the same issue by multiple sessions. Uses atomic file
+ * operations for crash-safe lock management.
+ */
+
+import { existsSync, mkdirSync, readdirSync, unlinkSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { hostname } from 'os';
+import { atomicWriteJson } from './fileOps.js';
+import type {
+  TaskLockData,
+  TaskLockResult,
+  TaskLockOptions,
+  TaskLockInfo,
+} from '../types/index.js';
+
+/** Default lock timeout in minutes (2 hours) */
+export const DEFAULT_LOCK_TIMEOUT_MINUTES = 120;
+
+/** Heartbeat interval in milliseconds (30 seconds) */
+export const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
+/** Name of the locks directory within .chadgi */
+export const LOCKS_DIRECTORY = 'locks';
+
+/**
+ * Generate a unique session ID for this process
+ */
+export function generateSessionId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `${hostname()}-${process.pid}-${timestamp}-${random}`;
+}
+
+/**
+ * Get the path to the locks directory
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @returns Path to the locks directory
+ */
+export function getLocksDir(chadgiDir: string): string {
+  return join(chadgiDir, LOCKS_DIRECTORY);
+}
+
+/**
+ * Get the lock file path for a specific issue
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number
+ * @returns Path to the lock file
+ */
+export function getLockFilePath(chadgiDir: string, issueNumber: number): string {
+  return join(getLocksDir(chadgiDir), `issue-${issueNumber}.lock`);
+}
+
+/**
+ * Ensure the locks directory exists
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ */
+export function ensureLocksDir(chadgiDir: string): void {
+  const locksDir = getLocksDir(chadgiDir);
+  if (!existsSync(locksDir)) {
+    mkdirSync(locksDir, { recursive: true });
+  }
+}
+
+/**
+ * Read a task lock file
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number
+ * @returns Lock data or null if no lock exists
+ */
+export function readTaskLock(chadgiDir: string, issueNumber: number): TaskLockData | null {
+  const lockPath = getLockFilePath(chadgiDir, issueNumber);
+  if (!existsSync(lockPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(lockPath, 'utf-8');
+    return JSON.parse(content) as TaskLockData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a lock is stale based on the last heartbeat time
+ *
+ * @param lock - The lock data
+ * @param timeoutMinutes - Timeout in minutes (default: DEFAULT_LOCK_TIMEOUT_MINUTES)
+ * @returns true if the lock is stale
+ */
+export function isLockStale(lock: TaskLockData, timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES): boolean {
+  const heartbeatTime = new Date(lock.last_heartbeat).getTime();
+  const now = Date.now();
+  const timeoutMs = timeoutMinutes * 60 * 1000;
+  return (now - heartbeatTime) > timeoutMs;
+}
+
+/**
+ * Check if a process is still running
+ *
+ * @param pid - Process ID to check
+ * @returns true if the process is running
+ */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    // Sending signal 0 doesn't actually send a signal,
+    // but will throw if the process doesn't exist
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempt to acquire a task lock
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number to lock
+ * @param sessionId - Unique session identifier
+ * @param options - Lock acquisition options
+ * @returns Result of the lock acquisition attempt
+ */
+export function acquireTaskLock(
+  chadgiDir: string,
+  issueNumber: number,
+  sessionId: string,
+  options: TaskLockOptions = {}
+): TaskLockResult {
+  const { forceClaim = false, timeoutMinutes = DEFAULT_LOCK_TIMEOUT_MINUTES, workerId, repoName } = options;
+
+  try {
+    ensureLocksDir(chadgiDir);
+
+    // Check for existing lock
+    const existingLock = readTaskLock(chadgiDir, issueNumber);
+
+    if (existingLock) {
+      // Check if the lock is owned by this session
+      if (existingLock.session_id === sessionId) {
+        // This session already owns the lock - refresh the heartbeat
+        const updatedLock: TaskLockData = {
+          ...existingLock,
+          last_heartbeat: new Date().toISOString(),
+        };
+        atomicWriteJson(getLockFilePath(chadgiDir, issueNumber), updatedLock);
+        return { acquired: true, lock: updatedLock };
+      }
+
+      // Check if the lock is stale
+      const stale = isLockStale(existingLock, timeoutMinutes);
+
+      // Check if the process is still running (only reliable on same machine)
+      const localLock = existingLock.hostname === hostname();
+      const processGone = localLock && !isProcessRunning(existingLock.pid);
+
+      if (forceClaim && (stale || processGone)) {
+        // Force claim a stale lock - remove it and acquire a new one
+        unlinkSync(getLockFilePath(chadgiDir, issueNumber));
+      } else if (stale || processGone) {
+        // Lock is stale but force claim not requested
+        return {
+          acquired: false,
+          lock: existingLock,
+          reason: 'stale_lock',
+          error: `Lock is stale (last heartbeat: ${existingLock.last_heartbeat}). Use --force-claim to override.`,
+        };
+      } else {
+        // Lock is held by another active session
+        return {
+          acquired: false,
+          lock: existingLock,
+          reason: 'already_locked',
+          error: `Issue #${issueNumber} is locked by session ${existingLock.session_id} on ${existingLock.hostname}`,
+        };
+      }
+    }
+
+    // Create new lock
+    const now = new Date().toISOString();
+    const newLock: TaskLockData = {
+      issue_number: issueNumber,
+      session_id: sessionId,
+      pid: process.pid,
+      hostname: hostname(),
+      locked_at: now,
+      last_heartbeat: now,
+      ...(workerId !== undefined && { worker_id: workerId }),
+      ...(repoName && { repo_name: repoName }),
+    };
+
+    atomicWriteJson(getLockFilePath(chadgiDir, issueNumber), newLock);
+
+    return { acquired: true, lock: newLock };
+  } catch (error) {
+    return {
+      acquired: false,
+      reason: 'error',
+      error: `Failed to acquire lock: ${(error as Error).message}`,
+    };
+  }
+}
+
+/**
+ * Release a task lock
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number to unlock
+ * @param sessionId - The session ID that owns the lock (for verification)
+ * @returns true if the lock was released
+ */
+export function releaseTaskLock(
+  chadgiDir: string,
+  issueNumber: number,
+  sessionId?: string
+): boolean {
+  const lockPath = getLockFilePath(chadgiDir, issueNumber);
+
+  if (!existsSync(lockPath)) {
+    return true; // No lock to release
+  }
+
+  // If sessionId provided, verify ownership
+  if (sessionId) {
+    const existingLock = readTaskLock(chadgiDir, issueNumber);
+    if (existingLock && existingLock.session_id !== sessionId) {
+      return false; // Not the owner
+    }
+  }
+
+  try {
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Force release a task lock (ignores ownership)
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number to unlock
+ * @returns true if the lock was released
+ */
+export function forceReleaseTaskLock(chadgiDir: string, issueNumber: number): boolean {
+  const lockPath = getLockFilePath(chadgiDir, issueNumber);
+
+  if (!existsSync(lockPath)) {
+    return true; // No lock to release
+  }
+
+  try {
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Update the heartbeat for a held lock
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number
+ * @param sessionId - The session ID that owns the lock
+ * @returns true if the heartbeat was updated
+ */
+export function updateLockHeartbeat(
+  chadgiDir: string,
+  issueNumber: number,
+  sessionId: string
+): boolean {
+  const existingLock = readTaskLock(chadgiDir, issueNumber);
+
+  if (!existingLock || existingLock.session_id !== sessionId) {
+    return false; // Not the owner or no lock
+  }
+
+  try {
+    const updatedLock: TaskLockData = {
+      ...existingLock,
+      last_heartbeat: new Date().toISOString(),
+    };
+    atomicWriteJson(getLockFilePath(chadgiDir, issueNumber), updatedLock);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all current task locks
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param timeoutMinutes - Timeout for determining staleness
+ * @returns Array of lock info objects
+ */
+export function listTaskLocks(
+  chadgiDir: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): TaskLockInfo[] {
+  const locksDir = getLocksDir(chadgiDir);
+
+  if (!existsSync(locksDir)) {
+    return [];
+  }
+
+  const locks: TaskLockInfo[] = [];
+
+  try {
+    const files = readdirSync(locksDir).filter(
+      (f) => f.startsWith('issue-') && f.endsWith('.lock')
+    );
+
+    const now = Date.now();
+
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(locksDir, file), 'utf-8');
+        const lock = JSON.parse(content) as TaskLockData;
+
+        const lockedAt = new Date(lock.locked_at).getTime();
+        const heartbeatAt = new Date(lock.last_heartbeat).getTime();
+
+        locks.push({
+          issueNumber: lock.issue_number,
+          sessionId: lock.session_id,
+          pid: lock.pid,
+          hostname: lock.hostname,
+          lockedAt: lock.locked_at,
+          lockedSeconds: Math.floor((now - lockedAt) / 1000),
+          heartbeatAgeSeconds: Math.floor((now - heartbeatAt) / 1000),
+          isStale: isLockStale(lock, timeoutMinutes),
+          workerId: lock.worker_id,
+          repoName: lock.repo_name,
+        });
+      } catch {
+        // Skip invalid lock files
+      }
+    }
+  } catch {
+    // Directory read error
+  }
+
+  return locks;
+}
+
+/**
+ * Find stale locks
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param timeoutMinutes - Timeout in minutes for staleness
+ * @returns Array of stale lock info objects
+ */
+export function findStaleLocks(
+  chadgiDir: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): TaskLockInfo[] {
+  return listTaskLocks(chadgiDir, timeoutMinutes).filter((lock) => lock.isStale);
+}
+
+/**
+ * Clean up stale locks
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param timeoutMinutes - Timeout in minutes for staleness
+ * @returns Number of stale locks removed
+ */
+export function cleanupStaleLocks(
+  chadgiDir: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): number {
+  const staleLocks = findStaleLocks(chadgiDir, timeoutMinutes);
+  let removedCount = 0;
+
+  for (const lock of staleLocks) {
+    if (forceReleaseTaskLock(chadgiDir, lock.issueNumber)) {
+      removedCount++;
+    }
+  }
+
+  return removedCount;
+}
+
+/**
+ * Check if an issue is locked
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number to check
+ * @returns true if the issue is locked
+ */
+export function isIssueLocked(chadgiDir: string, issueNumber: number): boolean {
+  return readTaskLock(chadgiDir, issueNumber) !== null;
+}
+
+/**
+ * Check if an issue is locked by another session
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number to check
+ * @param currentSessionId - The current session ID
+ * @param timeoutMinutes - Timeout for staleness check
+ * @returns true if locked by another active (non-stale) session
+ */
+export function isLockedByOther(
+  chadgiDir: string,
+  issueNumber: number,
+  currentSessionId: string,
+  timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES
+): boolean {
+  const lock = readTaskLock(chadgiDir, issueNumber);
+
+  if (!lock) {
+    return false;
+  }
+
+  // Same session owns the lock
+  if (lock.session_id === currentSessionId) {
+    return false;
+  }
+
+  // Check if lock is stale
+  if (isLockStale(lock, timeoutMinutes)) {
+    return false; // Stale locks don't count as blocking
+  }
+
+  // Check if process is gone (local only)
+  if (lock.hostname === hostname() && !isProcessRunning(lock.pid)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Start a heartbeat timer for a locked task
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param issueNumber - The issue number
+ * @param sessionId - The session ID
+ * @returns Timer reference (use clearInterval to stop)
+ */
+export function startHeartbeat(
+  chadgiDir: string,
+  issueNumber: number,
+  sessionId: string
+): ReturnType<typeof setInterval> {
+  return setInterval(() => {
+    updateLockHeartbeat(chadgiDir, issueNumber, sessionId);
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+/**
+ * Release all locks held by a specific session
+ *
+ * @param chadgiDir - Path to the .chadgi directory
+ * @param sessionId - The session ID
+ * @returns Number of locks released
+ */
+export function releaseAllSessionLocks(chadgiDir: string, sessionId: string): number {
+  const locks = listTaskLocks(chadgiDir);
+  let releasedCount = 0;
+
+  for (const lock of locks) {
+    if (lock.sessionId === sessionId) {
+      if (forceReleaseTaskLock(chadgiDir, lock.issueNumber)) {
+        releasedCount++;
+      }
+    }
+  }
+
+  return releasedCount;
+}

--- a/tests/test-session-stats.sh
+++ b/tests/test-session-stats.sh
@@ -140,7 +140,7 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 10: ctrl_c handler calls save_session_stats"
 
-if grep -A10 "^function ctrl_c()" "$PROJECT_ROOT/scripts/chadgi.sh" | grep -q 'save_session_stats'; then
+if grep -A15 "^function ctrl_c()" "$PROJECT_ROOT/scripts/chadgi.sh" | grep -q 'save_session_stats'; then
     pass "ctrl_c calls save_session_stats"
 else
     fail "ctrl_c should call save_session_stats"


### PR DESCRIPTION
## Summary
- Add issue-level locks in `.chadgi/locks/` directory when a task is claimed
- Lock files contain session ID, PID, hostname, and timestamps for distributed coordination
- Before claiming a task, check for existing lock and skip if locked by another session
- Add `--force-claim` flag to start command to override stale locks
- Add `task_lock_timeout_minutes` config option (default: 120 minutes)
- Include process heartbeat mechanism that updates lock file every 30 seconds
- Clean up locks on graceful shutdown and task completion/failure
- Add `chadgi doctor` check for stale locks with auto-fix capability
- Add `chadgi status` display showing active and stale task locks
- Add `chadgi unlock <issue-number>` command for manual lock release

## Test Plan
- [ ] Run `chadgi start` and verify lock file is created in `.chadgi/locks/issue-<N>.lock`
- [ ] Verify lock file contains session_id, pid, hostname, locked_at, last_heartbeat
- [ ] Run a second `chadgi start` and verify it skips locked issues with warning message
- [ ] Test `--force-claim` flag overrides stale locks (>2 hours old)
- [ ] Run `chadgi status` and verify task locks section appears when locks exist
- [ ] Run `chadgi doctor` and verify stale locks are detected
- [ ] Run `chadgi doctor --fix` and verify stale locks are cleaned up
- [ ] Run `chadgi unlock` (no args) to list all locks
- [ ] Run `chadgi unlock <issue-number>` to release specific lock
- [ ] Run `chadgi unlock --stale` to clean up only stale locks
- [ ] Verify locks are released on Ctrl+C (graceful shutdown)
- [ ] Verify locks are released after task completion
- [ ] Run `npm test` - all 509 tests pass

Closes #95

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces issue-level task locking to prevent concurrent processing, with heartbeat, timeout, and management tooling.
> 
> - Add `utils/locks.ts` with file-based locks (`.chadgi/locks/issue-<n>.lock`), heartbeat updates, stale detection, and helpers; comprehensive tests
> - Wire locks into `scripts/chadgi.sh`: acquire before claim, 30s heartbeat, release on completion/failure/Ctrl+C; support `FORCE_CLAIM` and `task_lock_timeout_minutes` (default 120)
> - CLI: new `--force-claim` flag in `start`; new `unlock` command (`list`, `--stale`, `--all`, `--force`) to manage locks
> - `doctor`: checks and optionally cleans up stale locks; `status`: displays active/stale lock summary
> - Schema: add `task_lock_timeout_minutes`; utils/data and tests updated to load/list locks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b18ba9e9304aa0d5f2aa5b27386c03a470f4bfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->