### PR TITLE
[CHAD] Migrate doctor, validate, history, insights commands to middleware pattern

### DIFF
--- a/src/doctor-middleware.ts
+++ b/src/doctor-middleware.ts
@@ -1,0 +1,1143 @@
+/**
+ * Doctor command implementation using the middleware system.
+ *
+ * This is a refactored version of doctor.ts that demonstrates the middleware
+ * pattern for reducing boilerplate.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { validateTemplateVariables, TemplateValidationResult } from './validate.js';
+import { maskObject, setMaskingDisabled } from './utils/secrets.js';
+import { colors } from './utils/colors.js';
+import { parseYamlValue, parseYamlNested } from './utils/config.js';
+import {
+  listTaskLocks,
+  findStaleLocks,
+  cleanupStaleLocks,
+  DEFAULT_LOCK_TIMEOUT_MINUTES,
+} from './utils/locks.js';
+import { checkMigrations, CURRENT_CONFIG_VERSION, DEFAULT_CONFIG_VERSION } from './migrations/index.js';
+
+// Import middleware utilities
+import {
+  withCommand,
+  withDirectory,
+  withDirectoryValidation,
+  type DirectoryContext,
+  type CommandResult,
+} from './utils/index.js';
+
+// Import shared types
+import type {
+  BaseCommandOptions,
+  ProgressData,
+  HealthCheck,
+  HealthReport,
+  RateLimitData,
+} from './types/index.js';
+
+/**
+ * Doctor command options.
+ */
+interface DoctorOptions extends BaseCommandOptions {
+  fix?: boolean;
+  mask?: boolean;  // --no-mask flag sets this to false
+}
+
+/**
+ * Check GitHub API rate limit status
+ */
+async function checkRateLimit(): Promise<HealthCheck[]> {
+  const checks: HealthCheck[] = [];
+
+  try {
+    const output = execSync('gh api rate_limit', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const rateData: RateLimitData = JSON.parse(output);
+
+    // Check core API rate limit
+    const core = rateData.resources.core;
+    const corePercentRemaining = (core.remaining / core.limit) * 100;
+
+    if (corePercentRemaining > 20) {
+      checks.push({
+        name: 'GitHub API Rate Limit (Core)',
+        category: 'api',
+        status: 'ok',
+        message: `${core.remaining}/${core.limit} requests remaining (${corePercentRemaining.toFixed(0)}%)`,
+      });
+    } else if (corePercentRemaining > 5) {
+      checks.push({
+        name: 'GitHub API Rate Limit (Core)',
+        category: 'api',
+        status: 'warning',
+        message: `Low: ${core.remaining}/${core.limit} requests remaining (${corePercentRemaining.toFixed(0)}%). Consider waiting before heavy operations.`,
+      });
+    } else {
+      const resetTime = new Date(core.reset * 1000).toLocaleTimeString();
+      checks.push({
+        name: 'GitHub API Rate Limit (Core)',
+        category: 'api',
+        status: 'error',
+        message: `Critical: Only ${core.remaining}/${core.limit} requests remaining. Resets at ${resetTime}`,
+      });
+    }
+
+    // Check GraphQL API rate limit
+    const graphql = rateData.resources.graphql;
+    const graphqlPercentRemaining = (graphql.remaining / graphql.limit) * 100;
+
+    if (graphqlPercentRemaining > 20) {
+      checks.push({
+        name: 'GitHub API Rate Limit (GraphQL)',
+        category: 'api',
+        status: 'ok',
+        message: `${graphql.remaining}/${graphql.limit} points remaining (${graphqlPercentRemaining.toFixed(0)}%)`,
+      });
+    } else if (graphqlPercentRemaining > 5) {
+      checks.push({
+        name: 'GitHub API Rate Limit (GraphQL)',
+        category: 'api',
+        status: 'warning',
+        message: `Low: ${graphql.remaining}/${graphql.limit} points remaining (${graphqlPercentRemaining.toFixed(0)}%)`,
+      });
+    } else {
+      const resetTime = new Date(graphql.reset * 1000).toLocaleTimeString();
+      checks.push({
+        name: 'GitHub API Rate Limit (GraphQL)',
+        category: 'api',
+        status: 'error',
+        message: `Critical: Only ${graphql.remaining}/${graphql.limit} points remaining. Resets at ${resetTime}`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'GitHub API Rate Limit',
+      category: 'api',
+      status: 'error',
+      message: `Could not check rate limit: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Check for stale task locks (issue-*.lock files)
+ */
+function checkStaleTaskLocks(chadgiDir: string, fix: boolean, timeoutMinutes: number = DEFAULT_LOCK_TIMEOUT_MINUTES): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+
+  try {
+    const allLocks = listTaskLocks(chadgiDir, timeoutMinutes);
+    const staleLocks = findStaleLocks(chadgiDir, timeoutMinutes);
+
+    if (allLocks.length === 0) {
+      checks.push({
+        name: 'Task Locks Check',
+        category: 'locks',
+        status: 'ok',
+        message: 'No task locks present',
+      });
+      return checks;
+    }
+
+    const activeLocks = allLocks.filter((l) => !l.isStale);
+
+    if (staleLocks.length === 0) {
+      checks.push({
+        name: 'Task Locks Check',
+        category: 'locks',
+        status: 'ok',
+        message: `${allLocks.length} active task lock(s) found`,
+      });
+      return checks;
+    }
+
+    if (fix) {
+      const removedCount = cleanupStaleLocks(chadgiDir, timeoutMinutes);
+      checks.push({
+        name: 'Task Locks Check',
+        category: 'locks',
+        status: 'warning',
+        message: `Removed ${removedCount} stale task lock(s). ${activeLocks.length} active lock(s) remain.`,
+        fixable: true,
+        fixed: true,
+      });
+    } else {
+      const issueNumbers = staleLocks.map((l) => `#${l.issueNumber}`).join(', ');
+      checks.push({
+        name: 'Task Locks Check',
+        category: 'locks',
+        status: 'warning',
+        message: `${staleLocks.length} stale task lock(s) found (issues: ${issueNumbers}). Use --fix to remove.`,
+        fixable: true,
+        fixed: false,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Task Locks Check',
+      category: 'locks',
+      status: 'error',
+      message: `Error checking task locks: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Check for stale pause.lock files (older than 24 hours)
+ */
+function checkStaleLockFiles(chadgiDir: string, fix: boolean): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+  const pauseLockFile = join(chadgiDir, 'pause.lock');
+
+  if (!existsSync(pauseLockFile)) {
+    checks.push({
+      name: 'Stale Lock File Check',
+      category: 'files',
+      status: 'ok',
+      message: 'No pause.lock file present',
+    });
+    return checks;
+  }
+
+  try {
+    const stats = statSync(pauseLockFile);
+    const ageHours = (Date.now() - stats.mtime.getTime()) / (1000 * 60 * 60);
+
+    if (ageHours > 24) {
+      if (fix) {
+        unlinkSync(pauseLockFile);
+        checks.push({
+          name: 'Stale Lock File Check',
+          category: 'files',
+          status: 'warning',
+          message: `Removed stale pause.lock (was ${ageHours.toFixed(1)} hours old)`,
+          fixable: true,
+          fixed: true,
+        });
+      } else {
+        checks.push({
+          name: 'Stale Lock File Check',
+          category: 'files',
+          status: 'warning',
+          message: `Stale pause.lock file found (${ageHours.toFixed(1)} hours old). Use --fix to remove.`,
+          fixable: true,
+          fixed: false,
+        });
+      }
+    } else {
+      // Read lock file to get reason
+      let reason = '';
+      try {
+        const lockContent = JSON.parse(readFileSync(pauseLockFile, 'utf-8'));
+        reason = lockContent.reason ? ` Reason: ${lockContent.reason}` : '';
+      } catch {
+        // ignore parse errors
+      }
+      checks.push({
+        name: 'Stale Lock File Check',
+        category: 'files',
+        status: 'ok',
+        message: `Active pause.lock (${ageHours.toFixed(1)} hours old).${reason}`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Stale Lock File Check',
+      category: 'files',
+      status: 'error',
+      message: `Error reading pause.lock: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Check for orphaned branches (feature branches with no open PR)
+ */
+async function checkOrphanedBranches(repo: string, branchPrefix: string): Promise<HealthCheck[]> {
+  const checks: HealthCheck[] = [];
+
+  try {
+    // Get remote branches matching the prefix
+    const remoteBranchesOutput = execSync('git branch -r', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const remoteBranches = remoteBranchesOutput
+      .split('\n')
+      .map(b => b.trim())
+      .filter(b => b.includes(branchPrefix))
+      .map(b => b.replace(/^origin\//, ''));
+
+    if (remoteBranches.length === 0) {
+      checks.push({
+        name: 'Orphaned Branches Check',
+        category: 'git',
+        status: 'ok',
+        message: 'No feature branches found',
+      });
+      return checks;
+    }
+
+    // Get open PRs for this repo
+    let openPRBranches: string[] = [];
+    try {
+      const prsOutput = execSync(`gh pr list --repo ${repo} --state open --json headRefName`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const prs = JSON.parse(prsOutput);
+      openPRBranches = prs.map((pr: { headRefName: string }) => pr.headRefName);
+    } catch {
+      // If we can't check PRs, we can't determine orphaned branches
+      checks.push({
+        name: 'Orphaned Branches Check',
+        category: 'git',
+        status: 'warning',
+        message: `Could not fetch open PRs. Found ${remoteBranches.length} feature branches.`,
+      });
+      return checks;
+    }
+
+    // Find branches without PRs
+    const orphanedBranches = remoteBranches.filter(b => !openPRBranches.includes(b));
+
+    if (orphanedBranches.length === 0) {
+      checks.push({
+        name: 'Orphaned Branches Check',
+        category: 'git',
+        status: 'ok',
+        message: `All ${remoteBranches.length} feature branches have open PRs`,
+      });
+    } else if (orphanedBranches.length <= 3) {
+      checks.push({
+        name: 'Orphaned Branches Check',
+        category: 'git',
+        status: 'warning',
+        message: `${orphanedBranches.length} orphaned branch(es): ${orphanedBranches.join(', ')}`,
+      });
+    } else {
+      checks.push({
+        name: 'Orphaned Branches Check',
+        category: 'git',
+        status: 'warning',
+        message: `${orphanedBranches.length} orphaned branches found. First 3: ${orphanedBranches.slice(0, 3).join(', ')}...`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Orphaned Branches Check',
+      category: 'git',
+      status: 'error',
+      message: `Could not check branches: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Verify project board connectivity and column existence
+ */
+async function checkProjectBoard(repo: string, projectNumber: string, columns: string[]): Promise<HealthCheck[]> {
+  const checks: HealthCheck[] = [];
+  const repoOwner = repo.split('/')[0];
+
+  try {
+    // Query the project to verify it exists and get field info
+    const query = `
+      query($owner: String!, $number: Int!) {
+        user(login: $owner) {
+          projectV2(number: $number) {
+            id
+            title
+            fields(first: 20) {
+              nodes {
+                ... on ProjectV2SingleSelectField {
+                  name
+                  options {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = execSync(
+      `gh api graphql -f query='${query}' -F owner='${repoOwner}' -F number=${projectNumber}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+
+    const data = JSON.parse(result);
+    const project = data.data?.user?.projectV2;
+
+    if (!project) {
+      // Try organization
+      const orgQuery = `
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+              title
+              fields(first: 20) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    name
+                    options {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      try {
+        const orgResult = execSync(
+          `gh api graphql -f query='${orgQuery}' -F owner='${repoOwner}' -F number=${projectNumber}`,
+          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        const orgData = JSON.parse(orgResult);
+        const orgProject = orgData.data?.organization?.projectV2;
+
+        if (!orgProject) {
+          checks.push({
+            name: 'Project Board Connectivity',
+            category: 'github',
+            status: 'error',
+            message: `Could not find project #${projectNumber} for ${repoOwner}`,
+          });
+          return checks;
+        }
+
+        // Use org project data
+        checks.push({
+          name: 'Project Board Connectivity',
+          category: 'github',
+          status: 'ok',
+          message: `Connected to project: "${orgProject.title}" (#${projectNumber})`,
+        });
+
+        // Check for Status field and columns
+        const statusField = orgProject.fields.nodes.find(
+          (f: { name: string }) => f.name === 'Status'
+        );
+
+        if (!statusField) {
+          checks.push({
+            name: 'Project Board Status Field',
+            category: 'github',
+            status: 'error',
+            message: 'Status field not found in project',
+          });
+          return checks;
+        }
+
+        const existingOptions = statusField.options?.map((o: { name: string }) => o.name) || [];
+        const missingColumns = columns.filter(c => !existingOptions.includes(c));
+
+        if (missingColumns.length === 0) {
+          checks.push({
+            name: 'Project Board Columns',
+            category: 'github',
+            status: 'ok',
+            message: `All required columns found: ${columns.join(', ')}`,
+          });
+        } else {
+          checks.push({
+            name: 'Project Board Columns',
+            category: 'github',
+            status: 'warning',
+            message: `Missing columns: ${missingColumns.join(', ')}. Available: ${existingOptions.join(', ')}`,
+          });
+        }
+
+        return checks;
+      } catch {
+        checks.push({
+          name: 'Project Board Connectivity',
+          category: 'github',
+          status: 'error',
+          message: `Could not find project #${projectNumber} for ${repoOwner}`,
+        });
+        return checks;
+      }
+    }
+
+    checks.push({
+      name: 'Project Board Connectivity',
+      category: 'github',
+      status: 'ok',
+      message: `Connected to project: "${project.title}" (#${projectNumber})`,
+    });
+
+    // Check for Status field and columns
+    const statusField = project.fields.nodes.find((f: { name: string }) => f.name === 'Status');
+
+    if (!statusField) {
+      checks.push({
+        name: 'Project Board Status Field',
+        category: 'github',
+        status: 'error',
+        message: 'Status field not found in project',
+      });
+      return checks;
+    }
+
+    const existingOptions = statusField.options?.map((o: { name: string }) => o.name) || [];
+    const missingColumns = columns.filter(c => !existingOptions.includes(c));
+
+    if (missingColumns.length === 0) {
+      checks.push({
+        name: 'Project Board Columns',
+        category: 'github',
+        status: 'ok',
+        message: `All required columns found: ${columns.join(', ')}`,
+      });
+    } else {
+      checks.push({
+        name: 'Project Board Columns',
+        category: 'github',
+        status: 'warning',
+        message: `Missing columns: ${missingColumns.join(', ')}. Available: ${existingOptions.join(', ')}`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Project Board Connectivity',
+      category: 'github',
+      status: 'error',
+      message: `Could not verify project board: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Test-render templates with mock data to catch syntax errors
+ */
+function checkTemplates(chadgiDir: string, configContent: string): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+
+  const promptTemplate = parseYamlValue(configContent, 'prompt_template') || './chadgi-task.md';
+  const generateTemplate = parseYamlValue(configContent, 'generate_template') || './chadgi-generate-task.md';
+
+  const templatePath = promptTemplate.startsWith('/') ? promptTemplate : join(chadgiDir, promptTemplate);
+  const generateTemplatePath = generateTemplate.startsWith('/') ? generateTemplate : join(chadgiDir, generateTemplate);
+
+  const templates = [
+    { path: templatePath, name: 'Task Template' },
+    { path: generateTemplatePath, name: 'Generate Template' },
+  ];
+
+  for (const { path, name } of templates) {
+    if (!existsSync(path)) {
+      checks.push({
+        name: `${name} Syntax`,
+        category: 'templates',
+        status: 'error',
+        message: `Template not found: ${path}`,
+      });
+      continue;
+    }
+
+    // Use the existing validateTemplateVariables function from validate.ts
+    const validation: TemplateValidationResult = validateTemplateVariables(path, []);
+
+    if (validation.unknownVariables.length === 0) {
+      checks.push({
+        name: `${name} Syntax`,
+        category: 'templates',
+        status: 'ok',
+        message: 'All template variables valid',
+      });
+    } else {
+      const unknownVars = validation.unknownVariables
+        .slice(0, 3)
+        .map(v => `{{${v.variable}}}`)
+        .join(', ');
+      const moreCount = validation.unknownVariables.length - 3;
+      const more = moreCount > 0 ? ` and ${moreCount} more` : '';
+
+      checks.push({
+        name: `${name} Syntax`,
+        category: 'templates',
+        status: 'warning',
+        message: `Unknown variables: ${unknownVars}${more}`,
+      });
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Check for pending/interrupted tasks in progress.json
+ */
+function checkProgressFile(chadgiDir: string): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+  const progressFile = join(chadgiDir, 'chadgi-progress.json');
+
+  if (!existsSync(progressFile)) {
+    checks.push({
+      name: 'Progress File Check',
+      category: 'state',
+      status: 'ok',
+      message: 'No progress file found (clean state)',
+    });
+    return checks;
+  }
+
+  try {
+    const progress: ProgressData = JSON.parse(readFileSync(progressFile, 'utf-8'));
+
+    if (progress.status === 'in_progress' && progress.current_task) {
+      const startedAt = new Date(progress.current_task.started_at);
+      const hoursAgo = (Date.now() - startedAt.getTime()) / (1000 * 60 * 60);
+
+      if (hoursAgo > 2) {
+        checks.push({
+          name: 'Progress File Check',
+          category: 'state',
+          status: 'warning',
+          message: `Potentially interrupted task #${progress.current_task.id} started ${hoursAgo.toFixed(1)} hours ago`,
+        });
+      } else {
+        checks.push({
+          name: 'Progress File Check',
+          category: 'state',
+          status: 'ok',
+          message: `Task #${progress.current_task.id} in progress (${hoursAgo.toFixed(1)} hours)`,
+        });
+      }
+    } else if (progress.status === 'paused') {
+      checks.push({
+        name: 'Progress File Check',
+        category: 'state',
+        status: 'ok',
+        message: 'ChadGI is paused',
+      });
+    } else if (progress.status === 'error') {
+      checks.push({
+        name: 'Progress File Check',
+        category: 'state',
+        status: 'warning',
+        message: 'Last session ended with an error',
+      });
+    } else {
+      checks.push({
+        name: 'Progress File Check',
+        category: 'state',
+        status: 'ok',
+        message: `Status: ${progress.status}`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Progress File Check',
+      category: 'state',
+      status: 'warning',
+      message: `Could not parse progress file: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Report disk space available in repo directory
+ */
+function checkDiskSpace(): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+
+  try {
+    // Use df command to get disk space
+    const output = execSync('df -h .', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const lines = output.trim().split('\n');
+
+    if (lines.length >= 2) {
+      const parts = lines[1].split(/\s+/);
+      // Format: Filesystem Size Used Avail Use% Mounted
+      const available = parts[3];
+      const usePercent = parseInt(parts[4]);
+
+      if (usePercent >= 95) {
+        checks.push({
+          name: 'Disk Space',
+          category: 'environment',
+          status: 'error',
+          message: `Critical: Only ${available} available (${usePercent}% used)`,
+        });
+      } else if (usePercent >= 85) {
+        checks.push({
+          name: 'Disk Space',
+          category: 'environment',
+          status: 'warning',
+          message: `Low disk space: ${available} available (${usePercent}% used)`,
+        });
+      } else {
+        checks.push({
+          name: 'Disk Space',
+          category: 'environment',
+          status: 'ok',
+          message: `${available} available (${usePercent}% used)`,
+        });
+      }
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Disk Space',
+      category: 'environment',
+      status: 'warning',
+      message: `Could not check disk space: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Summarize recent errors from diagnostics folder
+ */
+function checkDiagnosticsFolder(chadgiDir: string): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+  const diagnosticsDir = join(chadgiDir, 'diagnostics');
+
+  if (!existsSync(diagnosticsDir)) {
+    checks.push({
+      name: 'Recent Errors',
+      category: 'diagnostics',
+      status: 'ok',
+      message: 'No diagnostics folder found (no recent errors)',
+    });
+    return checks;
+  }
+
+  try {
+    const entries = readdirSync(diagnosticsDir)
+      .filter(name => {
+        const entryPath = join(diagnosticsDir, name);
+        return statSync(entryPath).isDirectory();
+      })
+      .sort()
+      .reverse();
+
+    if (entries.length === 0) {
+      checks.push({
+        name: 'Recent Errors',
+        category: 'diagnostics',
+        status: 'ok',
+        message: 'No diagnostic entries found',
+      });
+      return checks;
+    }
+
+    // Filter to last 7 days
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const recentEntries = entries.filter(name => {
+      const entryPath = join(diagnosticsDir, name);
+      const stats = statSync(entryPath);
+      return stats.mtime.getTime() > sevenDaysAgo;
+    });
+
+    if (recentEntries.length === 0) {
+      checks.push({
+        name: 'Recent Errors',
+        category: 'diagnostics',
+        status: 'ok',
+        message: `No errors in last 7 days (${entries.length} historical entries)`,
+      });
+    } else if (recentEntries.length <= 2) {
+      checks.push({
+        name: 'Recent Errors',
+        category: 'diagnostics',
+        status: 'ok',
+        message: `${recentEntries.length} error(s) in last 7 days`,
+      });
+    } else if (recentEntries.length <= 5) {
+      checks.push({
+        name: 'Recent Errors',
+        category: 'diagnostics',
+        status: 'warning',
+        message: `${recentEntries.length} errors in last 7 days. Check diagnostics folder.`,
+      });
+    } else {
+      checks.push({
+        name: 'Recent Errors',
+        category: 'diagnostics',
+        status: 'error',
+        message: `High error rate: ${recentEntries.length} errors in last 7 days`,
+      });
+    }
+  } catch (error) {
+    checks.push({
+      name: 'Recent Errors',
+      category: 'diagnostics',
+      status: 'warning',
+      message: `Could not read diagnostics folder: ${(error as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Calculate health score based on check results
+ */
+function calculateHealthScore(checks: HealthCheck[]): number {
+  if (checks.length === 0) return 100;
+
+  let score = 100;
+
+  // Weights by category
+  const categoryWeights: Record<string, number> = {
+    api: 15,
+    github: 20,
+    state: 15,
+    files: 10,
+    git: 10,
+    templates: 15,
+    environment: 10,
+    diagnostics: 5,
+    locks: 10,
+  };
+
+  // Penalty multipliers by status
+  const statusPenalties: Record<string, number> = {
+    error: 1.0,
+    warning: 0.5,
+    ok: 0,
+  };
+
+  for (const check of checks) {
+    const weight = categoryWeights[check.category] || 10;
+    const penalty = statusPenalties[check.status] || 0;
+
+    score -= weight * penalty;
+  }
+
+  // Normalize score
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+/**
+ * Generate recommendations based on check results
+ */
+function generateRecommendations(checks: HealthCheck[]): string[] {
+  const recommendations: string[] = [];
+
+  for (const check of checks) {
+    if (check.status === 'error') {
+      switch (check.category) {
+        case 'api':
+          recommendations.push('Wait for GitHub API rate limit to reset before running tasks');
+          break;
+        case 'github':
+          if (check.name.includes('Project Board')) {
+            recommendations.push('Run `chadgi setup-project` to configure your project board');
+          }
+          break;
+        case 'templates':
+          recommendations.push('Fix template errors to ensure proper task generation');
+          break;
+        case 'environment':
+          if (check.name === 'Disk Space') {
+            recommendations.push('Free up disk space before running ChadGI');
+          }
+          break;
+        case 'diagnostics':
+          recommendations.push('Review recent failures in .chadgi/diagnostics/ folder');
+          break;
+      }
+    } else if (check.status === 'warning') {
+      if (check.fixable && !check.fixed) {
+        recommendations.push(`Run \`chadgi doctor --fix\` to auto-fix: ${check.name}`);
+      }
+      if (check.name === 'Orphaned Branches Check') {
+        recommendations.push('Consider cleaning up orphaned feature branches');
+      }
+      if (check.name.includes('Progress File') && check.message.includes('interrupted')) {
+        recommendations.push('Check if an interrupted task needs manual resolution');
+      }
+      if (check.name === 'Task Locks Check' && check.message.includes('stale')) {
+        recommendations.push('Run `chadgi unlock --stale` to clean up stale task locks');
+      }
+      if (check.name === 'Config Version Migration') {
+        recommendations.push('Run `chadgi config migrate` to update your configuration schema');
+      }
+    }
+  }
+
+  // Remove duplicates
+  return [...new Set(recommendations)];
+}
+
+/**
+ * Print health report to console
+ */
+function printReport(report: HealthReport): void {
+  console.log(`${colors.purple}${colors.bold}`);
+  console.log('==========================================================');
+  console.log('                    CHADGI DOCTOR                          ');
+  console.log('==========================================================');
+  console.log(`${colors.reset}`);
+
+  // Health score with color coding
+  let scoreColor: string = colors.green;
+  if (report.healthScore < 70) {
+    scoreColor = colors.red;
+  } else if (report.healthScore < 85) {
+    scoreColor = colors.yellow;
+  }
+
+  console.log(`${colors.cyan}${colors.bold}Health Score:${colors.reset} ${scoreColor}${colors.bold}${report.healthScore}/100${colors.reset}`);
+  console.log('');
+
+  // Summary
+  console.log(`${colors.dim}Summary: ${report.summary.passed} passed, ${report.summary.warnings} warnings, ${report.summary.errors} errors${colors.reset}`);
+  console.log('');
+
+  // Group checks by category
+  const categories = [...new Set(report.checks.map(c => c.category))];
+
+  for (const category of categories) {
+    const categoryChecks = report.checks.filter(c => c.category === category);
+    const categoryTitle = category.charAt(0).toUpperCase() + category.slice(1);
+
+    console.log(`${colors.cyan}${colors.bold}${categoryTitle}${colors.reset}`);
+
+    for (const check of categoryChecks) {
+      let icon: string;
+      let color: string;
+
+      switch (check.status) {
+        case 'ok':
+          icon = '+';
+          color = colors.green;
+          break;
+        case 'warning':
+          icon = '!';
+          color = colors.yellow;
+          break;
+        case 'error':
+          icon = 'x';
+          color = colors.red;
+          break;
+        default:
+          icon = '?';
+          color = colors.dim;
+      }
+
+      const fixedIndicator = check.fixed ? ` ${colors.green}(fixed)${colors.reset}` : '';
+      console.log(`  ${color}${icon}${colors.reset} ${check.name}: ${check.message}${fixedIndicator}`);
+    }
+    console.log('');
+  }
+
+  // Recommendations
+  if (report.recommendations.length > 0) {
+    console.log(`${colors.yellow}${colors.bold}Recommendations:${colors.reset}`);
+    for (const rec of report.recommendations) {
+      console.log(`  ${colors.yellow}*${colors.reset} ${rec}`);
+    }
+    console.log('');
+  }
+
+  // Footer
+  if (report.healthScore >= 85) {
+    console.log(`${colors.green}${colors.bold}ChadGI is healthy and ready to work!${colors.reset}`);
+  } else if (report.healthScore >= 70) {
+    console.log(`${colors.yellow}${colors.bold}ChadGI can run but some issues should be addressed.${colors.reset}`);
+  } else {
+    console.log(`${colors.red}${colors.bold}ChadGI has issues that should be fixed before running.${colors.reset}`);
+  }
+
+  console.log('');
+  console.log(`${colors.purple}${colors.bold}==========================================================`);
+  console.log('               Chad does what Chad wants.');
+  console.log(`==========================================================${colors.reset}`);
+}
+
+/**
+ * Doctor command handler using middleware pattern.
+ *
+ * Note how the handler is now focused purely on business logic:
+ * - No try/catch needed (handled by withErrorHandler)
+ * - No config path resolution (handled by withDirectory)
+ * - No directory validation (handled by withDirectoryValidation)
+ * - JSON output is handled automatically when result.data is returned
+ */
+async function doctorHandler(
+  ctx: DirectoryContext<DoctorOptions>
+): Promise<CommandResult> {
+  const { chadgiDir, configPath, options } = ctx;
+  const fix = options.fix || false;
+
+  // Handle --no-mask flag (Commander sets mask=false when --no-mask is used)
+  const noMask = options.mask === false;
+  if (noMask) {
+    setMaskingDisabled(true);
+    if (!options.json) {
+      console.log(`${colors.yellow}WARNING: Secret masking is DISABLED. Sensitive data may be exposed in output.${colors.reset}\n`);
+    }
+  }
+
+  if (!options.json) {
+    console.log('Running ChadGI health checks...\n');
+  }
+
+  const checks: HealthCheck[] = [];
+
+  // Load config for project-specific checks
+  let configContent = '';
+  let repo = 'owner/repo';
+  let projectNumber = '1';
+  let branchPrefix = 'feature/issue-';
+  let readyColumn = 'Ready';
+  let inProgressColumn = 'In Progress';
+  let reviewColumn = 'In Review';
+
+  if (existsSync(configPath)) {
+    configContent = readFileSync(configPath, 'utf-8');
+    repo = parseYamlNested(configContent, 'github', 'repo') || repo;
+    projectNumber = parseYamlNested(configContent, 'github', 'project_number') || projectNumber;
+    branchPrefix = parseYamlNested(configContent, 'branch', 'prefix') || branchPrefix;
+    readyColumn = parseYamlNested(configContent, 'github', 'ready_column') || readyColumn;
+    inProgressColumn = parseYamlNested(configContent, 'github', 'in_progress_column') || inProgressColumn;
+    reviewColumn = parseYamlNested(configContent, 'github', 'review_column') || reviewColumn;
+
+    checks.push({
+      name: 'Configuration File',
+      category: 'files',
+      status: 'ok',
+      message: `Loaded from ${configPath}`,
+    });
+
+    // Check for pending migrations
+    const migrationCheck = checkMigrations(configPath);
+    if (migrationCheck.needsMigration) {
+      const currentVer = migrationCheck.currentVersion || DEFAULT_CONFIG_VERSION;
+      checks.push({
+        name: 'Config Version Migration',
+        category: 'files',
+        status: 'warning',
+        message: `Migration available: ${currentVer} -> ${CURRENT_CONFIG_VERSION}. Run 'chadgi config migrate'`,
+        fixable: true,
+        fixed: false,
+      });
+    } else {
+      checks.push({
+        name: 'Config Version',
+        category: 'files',
+        status: 'ok',
+        message: `Version ${CURRENT_CONFIG_VERSION} (current)`,
+      });
+    }
+  } else {
+    checks.push({
+      name: 'Configuration File',
+      category: 'files',
+      status: 'error',
+      message: `Not found: ${configPath}`,
+    });
+  }
+
+  // Run all health checks
+  const requiredColumns = [readyColumn, inProgressColumn, reviewColumn];
+
+  // API checks
+  checks.push(...(await checkRateLimit()));
+
+  // File checks
+  checks.push(...checkStaleLockFiles(chadgiDir, fix));
+
+  // Task locks checks
+  checks.push(...checkStaleTaskLocks(chadgiDir, fix));
+
+  // Git checks (only if repo is configured)
+  if (repo !== 'owner/repo') {
+    checks.push(...(await checkOrphanedBranches(repo, branchPrefix)));
+
+    // Project board checks
+    checks.push(...(await checkProjectBoard(repo, projectNumber, requiredColumns)));
+  } else {
+    checks.push({
+      name: 'Repository Configuration',
+      category: 'github',
+      status: 'warning',
+      message: 'Repository not configured (using default owner/repo)',
+    });
+  }
+
+  // Template checks
+  if (configContent) {
+    checks.push(...checkTemplates(chadgiDir, configContent));
+  }
+
+  // State checks
+  checks.push(...checkProgressFile(chadgiDir));
+
+  // Environment checks
+  checks.push(...checkDiskSpace());
+
+  // Diagnostics checks
+  checks.push(...checkDiagnosticsFolder(chadgiDir));
+
+  // Build report
+  const healthScore = calculateHealthScore(checks);
+  const recommendations = generateRecommendations(checks);
+
+  const report: HealthReport = {
+    timestamp: new Date().toISOString(),
+    healthScore,
+    checks,
+    recommendations,
+    summary: {
+      total: checks.length,
+      passed: checks.filter(c => c.status === 'ok').length,
+      warnings: checks.filter(c => c.status === 'warning').length,
+      errors: checks.filter(c => c.status === 'error').length,
+    },
+  };
+
+  // Output (apply secret masking to report messages)
+  const maskedReport = maskObject(report);
+
+  if (options.json) {
+    return { data: maskedReport };
+  }
+
+  printReport(maskedReport);
+
+  // Exit with error code if health score is critical
+  if (healthScore < 50) {
+    process.exit(1);
+  }
+
+  return { success: true };
+}
+
+/**
+ * Doctor command with middleware applied.
+ *
+ * The middleware chain:
+ * 1. withTiming - tracks execution time (added automatically)
+ * 2. withErrorHandler - catches and formats errors (added automatically)
+ * 3. withJsonOutput - handles JSON serialization (added automatically)
+ * 4. withDirectory - resolves chadgiDir and configPath
+ * 5. withDirectoryValidation - ensures .chadgi directory exists
+ */
+export const doctorMiddleware = withCommand<DoctorOptions, DirectoryContext<DoctorOptions>>(
+  [withDirectory, withDirectoryValidation] as any,
+  doctorHandler
+);

--- a/src/history-middleware.ts
+++ b/src/history-middleware.ts
@@ -1,0 +1,370 @@
+/**
+ * History command implementation using the middleware system.
+ *
+ * This is a refactored version of history.ts that demonstrates the middleware
+ * pattern for reducing boilerplate.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+
+// Import shared utilities
+import { colors } from './utils/colors.js';
+import { parseYamlNested } from './utils/config.js';
+import { formatDuration, formatDate, formatCost, parseSince, horizontalLine, truncate } from './utils/formatting.js';
+import { loadSessionStats, loadTaskMetrics } from './utils/data.js';
+import { fetchIssueTitle, fetchPrUrl } from './utils/github.js';
+
+// Import middleware utilities
+import {
+  withCommand,
+  withDirectory,
+  withDirectoryValidation,
+  type DirectoryContext,
+  type CommandResult,
+} from './utils/index.js';
+
+// Import shared types
+import type { BaseCommandOptions, SessionStats, TaskMetrics, HistoryEntry, HistoryResult } from './types/index.js';
+
+/**
+ * History command options.
+ */
+interface HistoryOptions extends BaseCommandOptions {
+  limit?: number;
+  since?: string;
+  status?: string;
+}
+
+/**
+ * Build unified history entries from both data sources
+ */
+function buildHistoryEntries(
+  sessions: SessionStats[],
+  metrics: TaskMetrics[],
+  _repo: string
+): HistoryEntry[] {
+  const entries: HistoryEntry[] = [];
+  const processedIssues = new Set<string>(); // Use issue+timestamp to avoid duplicates
+
+  // Process detailed metrics first (more accurate data)
+  for (const metric of metrics) {
+    const key = `${metric.issue_number}-${metric.started_at}`;
+    if (processedIssues.has(key)) continue;
+    processedIssues.add(key);
+
+    entries.push({
+      issueNumber: metric.issue_number,
+      outcome: metric.status === 'completed' ? 'success' : 'failed',
+      elapsedTime: metric.duration_secs || 0,
+      cost: metric.cost_usd > 0 ? metric.cost_usd : undefined,
+      startedAt: metric.started_at,
+      completedAt: metric.completed_at,
+      failureReason: metric.failure_reason,
+      category: metric.category,
+      iterations: metric.iterations,
+    });
+  }
+
+  // Process session stats for entries not covered by metrics
+  for (const session of sessions) {
+    // Process successful tasks
+    for (const task of session.successful_tasks || []) {
+      const key = `${task.issue}-${session.started_at}`;
+      if (processedIssues.has(key)) continue;
+      processedIssues.add(key);
+
+      entries.push({
+        issueNumber: task.issue,
+        outcome: 'success',
+        elapsedTime: task.duration_secs || 0,
+        startedAt: session.started_at,
+        completedAt: session.ended_at,
+      });
+    }
+
+    // Process failed tasks
+    for (const task of session.failed_tasks || []) {
+      const key = `${task.issue}-${session.started_at}`;
+      if (processedIssues.has(key)) continue;
+      processedIssues.add(key);
+
+      entries.push({
+        issueNumber: task.issue,
+        outcome: task.reason?.toLowerCase().includes('skip') ? 'skipped' : 'failed',
+        elapsedTime: task.duration_secs || 0,
+        startedAt: session.started_at,
+        completedAt: session.ended_at,
+        failureReason: task.reason,
+      });
+    }
+  }
+
+  // Sort by startedAt descending (most recent first)
+  entries.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+
+  return entries;
+}
+
+/**
+ * Apply filters to history entries
+ */
+function applyFilters(
+  entries: HistoryEntry[],
+  options: HistoryOptions
+): { filtered: HistoryEntry[]; sinceDate?: Date; statusFilter?: string } {
+  let filtered = [...entries];
+  let sinceDate: Date | undefined;
+  let statusFilter: string | undefined;
+
+  // Apply --since filter
+  if (options.since) {
+    sinceDate = parseSince(options.since) || undefined;
+    if (sinceDate) {
+      const sinceTime = sinceDate.getTime();
+      filtered = filtered.filter(
+        (entry) => new Date(entry.startedAt).getTime() >= sinceTime
+      );
+    } else {
+      console.error(`Warning: Could not parse --since value: ${options.since}`);
+      console.error('Supported formats: "7d", "2w", "1m", "2024-01-01"');
+    }
+  }
+
+  // Apply --status filter
+  if (options.status) {
+    statusFilter = options.status.toLowerCase();
+    if (statusFilter === 'success' || statusFilter === 'completed') {
+      filtered = filtered.filter((entry) => entry.outcome === 'success');
+    } else if (statusFilter === 'failed' || statusFilter === 'failure') {
+      filtered = filtered.filter((entry) => entry.outcome === 'failed');
+    } else if (statusFilter === 'skipped') {
+      filtered = filtered.filter((entry) => entry.outcome === 'skipped');
+    } else {
+      console.error(`Warning: Unknown status filter: ${options.status}`);
+      console.error('Supported values: success, failed, skipped');
+    }
+  }
+
+  // Apply --limit
+  if (options.limit && options.limit > 0) {
+    filtered = filtered.slice(0, options.limit);
+  }
+
+  return { filtered, sinceDate, statusFilter };
+}
+
+/**
+ * Print formatted history output
+ */
+function printHistory(
+  entries: HistoryEntry[],
+  total: number,
+  sinceDate?: Date,
+  statusFilter?: string,
+  _repo?: string
+): void {
+  console.log(`${colors.purple}${colors.bold}`);
+  console.log('==========================================================');
+  console.log('                  CHADGI TASK HISTORY                      ');
+  console.log('==========================================================');
+  console.log(`${colors.reset}`);
+
+  // Show filters if applied
+  if (sinceDate || statusFilter) {
+    console.log(`${colors.dim}Filters applied:`);
+    if (sinceDate) {
+      console.log(`  Since: ${formatDate(sinceDate.toISOString())}`);
+    }
+    if (statusFilter) {
+      console.log(`  Status: ${statusFilter}`);
+    }
+    console.log(`${colors.reset}`);
+    console.log('');
+  }
+
+  if (entries.length === 0) {
+    console.log(`${colors.yellow}No task history found matching the specified criteria.${colors.reset}`);
+    console.log('');
+    console.log('Run `chadgi start` to begin processing tasks and build history.');
+    return;
+  }
+
+  // Summary
+  console.log(`${colors.cyan}Showing ${entries.length} of ${total} total tasks${colors.reset}`);
+  console.log('');
+
+  // Calculate summary stats
+  const successful = entries.filter((e) => e.outcome === 'success').length;
+  const failed = entries.filter((e) => e.outcome === 'failed').length;
+  const skipped = entries.filter((e) => e.outcome === 'skipped').length;
+  const totalCost = entries.reduce((sum, e) => sum + (e.cost || 0), 0);
+  const totalTime = entries.reduce((sum, e) => sum + e.elapsedTime, 0);
+
+  console.log(`${colors.cyan}${colors.bold}Summary${colors.reset}`);
+  console.log(`  ${colors.green}Success:${colors.reset} ${successful}`);
+  console.log(`  ${colors.red}Failed:${colors.reset}  ${failed}`);
+  if (skipped > 0) {
+    console.log(`  ${colors.yellow}Skipped:${colors.reset} ${skipped}`);
+  }
+  console.log(`  Total Time: ${formatDuration(totalTime)}`);
+  if (totalCost > 0) {
+    console.log(`  Total Cost: ${formatCost(totalCost)}`);
+  }
+  console.log('');
+
+  // Task list header
+  console.log(`${colors.cyan}${colors.bold}Task History${colors.reset}`);
+  console.log(`${colors.dim}${horizontalLine(78)}${colors.reset}`);
+
+  // Task entries
+  for (const entry of entries) {
+    const outcomeColor =
+      entry.outcome === 'success'
+        ? colors.green
+        : entry.outcome === 'skipped'
+          ? colors.yellow
+          : colors.red;
+
+    const outcomeText =
+      entry.outcome === 'success'
+        ? 'SUCCESS'
+        : entry.outcome === 'skipped'
+          ? 'SKIPPED'
+          : 'FAILED';
+
+    // Issue line
+    console.log(
+      `${colors.bold}#${entry.issueNumber}${colors.reset} ${outcomeColor}[${outcomeText}]${colors.reset}`
+    );
+
+    // Title if available
+    if (entry.issueTitle) {
+      console.log(`  ${colors.dim}${truncate(entry.issueTitle, 60)}${colors.reset}`);
+    }
+
+    // Details
+    console.log(`  Date:    ${formatDate(entry.startedAt)}`);
+    console.log(`  Elapsed: ${formatDuration(entry.elapsedTime)}`);
+
+    if (entry.cost !== undefined && entry.cost > 0) {
+      console.log(`  Cost:    ${formatCost(entry.cost)}`);
+    }
+
+    if (entry.category) {
+      console.log(`  Category: ${entry.category}`);
+    }
+
+    if (entry.iterations && entry.iterations > 1) {
+      console.log(`  Iterations: ${entry.iterations}`);
+    }
+
+    // Failure reason if applicable
+    if (entry.outcome === 'failed' && entry.failureReason) {
+      console.log(`  ${colors.red}Reason: ${entry.failureReason}${colors.reset}`);
+    }
+
+    // PR URL if available
+    if (entry.prUrl) {
+      console.log(`  ${colors.blue}PR: ${entry.prUrl}${colors.reset}`);
+    }
+
+    console.log(`${colors.dim}${horizontalLine(78)}${colors.reset}`);
+  }
+
+  console.log('');
+  console.log(`${colors.purple}${colors.bold}==========================================================`);
+  console.log('               Chad does what Chad wants.');
+  console.log(`==========================================================${colors.reset}`);
+}
+
+/**
+ * History command handler using middleware pattern.
+ *
+ * Note how the handler is now focused purely on business logic:
+ * - No try/catch needed (handled by withErrorHandler)
+ * - No config path resolution (handled by withDirectory)
+ * - No directory validation (handled by withDirectoryValidation)
+ * - JSON output is handled automatically when result.data is returned
+ */
+async function historyHandler(
+  ctx: DirectoryContext<HistoryOptions>
+): Promise<CommandResult> {
+  const { chadgiDir, configPath, options } = ctx;
+
+  // Load config for repo info
+  let repo = 'owner/repo';
+  if (existsSync(configPath)) {
+    const configContent = readFileSync(configPath, 'utf-8');
+    repo = parseYamlNested(configContent, 'github', 'repo') || repo;
+  }
+
+  // Load data from both sources
+  const sessions = loadSessionStats(chadgiDir);
+  const metrics = loadTaskMetrics(chadgiDir);
+
+  // Build unified history entries
+  const allEntries = buildHistoryEntries(sessions, metrics, repo);
+
+  // Apply filters
+  const defaultLimit = 10;
+  const effectiveLimit = options.limit ?? (options.since || options.status ? undefined : defaultLimit);
+  const { filtered, sinceDate, statusFilter } = applyFilters(allEntries, {
+    ...options,
+    limit: effectiveLimit,
+  });
+
+  // Optionally fetch issue titles and PR URLs for successful tasks
+  // (only for displayed entries to minimize API calls)
+  if (!options.json && repo !== 'owner/repo') {
+    for (const entry of filtered) {
+      // Fetch issue title if not already set
+      if (!entry.issueTitle) {
+        entry.issueTitle = fetchIssueTitle(entry.issueNumber, repo) || undefined;
+      }
+
+      // Fetch PR URL for successful tasks
+      if (entry.outcome === 'success' && !entry.prUrl) {
+        entry.prUrl = fetchPrUrl(entry.issueNumber, repo) || undefined;
+      }
+    }
+  }
+
+  // Output as JSON if requested
+  if (options.json) {
+    const result: HistoryResult = {
+      entries: filtered,
+      total: allEntries.length,
+      filtered: filtered.length,
+    };
+    if (sinceDate) {
+      result.dateRange = {
+        since: sinceDate.toISOString(),
+        until: new Date().toISOString(),
+      };
+    }
+    if (statusFilter) {
+      result.statusFilter = statusFilter;
+    }
+    return { data: result };
+  }
+
+  // Display formatted history
+  printHistory(filtered, allEntries.length, sinceDate, statusFilter, repo);
+
+  return { success: true };
+}
+
+/**
+ * History command with middleware applied.
+ *
+ * The middleware chain:
+ * 1. withTiming - tracks execution time (added automatically)
+ * 2. withErrorHandler - catches and formats errors (added automatically)
+ * 3. withJsonOutput - handles JSON serialization (added automatically)
+ * 4. withDirectory - resolves chadgiDir and configPath
+ * 5. withDirectoryValidation - ensures .chadgi directory exists
+ */
+export const historyMiddleware = withCommand<HistoryOptions, DirectoryContext<HistoryOptions>>(
+  [withDirectory, withDirectoryValidation] as any,
+  historyHandler
+);

--- a/src/insights-middleware.ts
+++ b/src/insights-middleware.ts
@@ -1,0 +1,680 @@
+/**
+ * Insights command implementation using the middleware system.
+ *
+ * This is a refactored version of insights.ts that demonstrates the middleware
+ * pattern for reducing boilerplate.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { colors } from './utils/colors.js';
+import { formatDuration } from './utils/formatting.js';
+
+// Import middleware utilities
+import {
+  withCommand,
+  withDirectory,
+  withDirectoryValidation,
+  type DirectoryContext,
+  type CommandResult,
+} from './utils/index.js';
+
+// Import shared types
+import type {
+  BaseCommandOptions,
+  SessionStats,
+  TaskMetrics,
+  MetricsData,
+} from './types/index.js';
+
+/**
+ * Insights command options.
+ */
+interface InsightsOptions extends BaseCommandOptions {
+  export?: string;
+  days?: number;
+  category?: string;
+}
+
+/**
+ * Category statistics for breakdown
+ */
+interface CategoryStats {
+  tasks: number;
+  completed: number;
+  failed: number;
+  successRate: number;
+  avgDuration: number;
+  totalCost: number;
+}
+
+function calculatePercentile(values: number[], percentile: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((percentile / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+function calculateMedian(values: number[]): number {
+  return calculatePercentile(values, 50);
+}
+
+function calculateStdDev(values: number[]): number {
+  if (values.length === 0) return 0;
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  const squaredDiffs = values.map((v) => Math.pow(v - avg, 2));
+  return Math.sqrt(squaredDiffs.reduce((a, b) => a + b, 0) / values.length);
+}
+
+/**
+ * Generate ASCII histogram
+ */
+function generateHistogram(
+  values: number[],
+  bins: number = 5,
+  width: number = 20
+): string[] {
+  if (values.length === 0) return ['No data'];
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const binSize = range / bins;
+
+  const histogram: number[] = new Array(bins).fill(0);
+  for (const v of values) {
+    const binIndex = Math.min(Math.floor((v - min) / binSize), bins - 1);
+    histogram[binIndex]++;
+  }
+
+  const maxCount = Math.max(...histogram);
+  const lines: string[] = [];
+
+  for (let i = 0; i < bins; i++) {
+    const rangeStart = min + i * binSize;
+    const rangeEnd = min + (i + 1) * binSize;
+    const barLength = maxCount > 0 ? Math.round((histogram[i] / maxCount) * width) : 0;
+    const bar = '\u2588'.repeat(barLength);
+    const label = `${formatDuration(rangeStart)}-${formatDuration(rangeEnd)}`;
+    lines.push(`  ${label.padEnd(20)} ${bar} ${histogram[i]}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Load and merge data from both stats and metrics files
+ */
+function loadInsightsData(chadgiDir: string, days?: number): {
+  sessions: SessionStats[];
+  tasks: TaskMetrics[];
+} {
+  const statsFile = join(chadgiDir, 'chadgi-stats.json');
+  const metricsFile = join(chadgiDir, 'chadgi-metrics.json');
+
+  let sessions: SessionStats[] = [];
+  let tasks: TaskMetrics[] = [];
+
+  // Load session stats
+  if (existsSync(statsFile)) {
+    try {
+      const content = readFileSync(statsFile, 'utf-8');
+      sessions = JSON.parse(content);
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  // Load detailed metrics
+  if (existsSync(metricsFile)) {
+    try {
+      const content = readFileSync(metricsFile, 'utf-8');
+      const metricsData: MetricsData = JSON.parse(content);
+      tasks = metricsData.tasks || [];
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  // Apply retention filter if specified
+  if (days && days > 0) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffStr = cutoff.toISOString();
+
+    sessions = sessions.filter((s) => s.started_at >= cutoffStr);
+    tasks = tasks.filter((t) => t.started_at >= cutoffStr);
+  }
+
+  return { sessions, tasks };
+}
+
+/**
+ * Build task metrics from session stats when detailed metrics are not available
+ */
+function buildTaskMetricsFromSessions(sessions: SessionStats[]): TaskMetrics[] {
+  const tasks: TaskMetrics[] = [];
+
+  for (const session of sessions) {
+    // Add successful tasks
+    for (const task of session.successful_tasks || []) {
+      tasks.push({
+        issue_number: task.issue,
+        started_at: session.started_at,
+        duration_secs: task.duration_secs || 0,
+        status: 'completed',
+        iterations: 1, // Unknown from basic stats
+        cost_usd: 0, // Unknown per-task
+      });
+    }
+
+    // Add failed tasks
+    for (const task of session.failed_tasks || []) {
+      tasks.push({
+        issue_number: task.issue,
+        started_at: session.started_at,
+        duration_secs: 0, // Unknown
+        status: 'failed',
+        iterations: 1,
+        cost_usd: 0,
+        failure_reason: task.reason,
+      });
+    }
+  }
+
+  return tasks;
+}
+
+interface AnalysisResults {
+  // Overview
+  totalTasks: number;
+  completedTasks: number;
+  failedTasks: number;
+  successRate: number;
+
+  // Duration stats
+  avgDuration: number;
+  medianDuration: number;
+  minDuration: number;
+  maxDuration: number;
+  stdDevDuration: number;
+  p90Duration: number;
+  durations: number[];
+
+  // Cost stats
+  totalCost: number;
+  avgCostPerTask: number;
+  avgCostPerSuccessfulTask: number;
+  costs: number[];
+
+  // Iteration stats
+  avgIterations: number;
+  totalIterations: number;
+  iterationsDistribution: Record<number, number>;
+
+  // Failure analysis
+  failuresByReason: Record<string, number>;
+  failuresByPhase: Record<string, number>;
+
+  // Phase timing (if available)
+  avgPhase1Duration: number;
+  avgPhase2Duration: number;
+  avgVerificationDuration: number;
+  phaseBreakdown: {
+    phase1Pct: number;
+    phase2Pct: number;
+    verificationPct: number;
+  };
+
+  // Complexity (if available)
+  avgFilesModified: number;
+  avgLinesChanged: number;
+
+  // Sessions
+  totalSessions: number;
+  totalSessionDuration: number;
+  avgSessionDuration: number;
+  gigachadMerges: number;
+
+  // Trends
+  recentSuccessRate: number; // Last 10 tasks
+  recentAvgDuration: number;
+
+  // Category breakdown
+  categoryBreakdown: Record<string, CategoryStats>;
+}
+
+function analyzeData(
+  sessions: SessionStats[],
+  tasks: TaskMetrics[]
+): AnalysisResults {
+  // Use tasks from metrics if available, otherwise derive from sessions
+  const taskList = tasks.length > 0 ? tasks : buildTaskMetricsFromSessions(sessions);
+
+  const completedTasks = taskList.filter((t) => t.status === 'completed');
+  const failedTasks = taskList.filter((t) => t.status === 'failed');
+  const durations = completedTasks.map((t) => t.duration_secs).filter((d) => d > 0);
+  const costs = taskList.map((t) => t.cost_usd).filter((c) => c > 0);
+
+  // Failure analysis
+  const failuresByReason: Record<string, number> = {};
+  const failuresByPhase: Record<string, number> = {};
+  for (const task of failedTasks) {
+    const reason = task.failure_reason || 'unknown';
+    failuresByReason[reason] = (failuresByReason[reason] || 0) + 1;
+    if (task.failure_phase) {
+      failuresByPhase[task.failure_phase] = (failuresByPhase[task.failure_phase] || 0) + 1;
+    }
+  }
+
+  // Iteration distribution
+  const iterationsDistribution: Record<number, number> = {};
+  for (const task of taskList) {
+    const iter = task.iterations || 1;
+    iterationsDistribution[iter] = (iterationsDistribution[iter] || 0) + 1;
+  }
+
+  // Phase timing
+  const tasksWithPhases = tasks.filter((t) => t.phases);
+  let avgPhase1 = 0, avgPhase2 = 0, avgVerification = 0;
+  if (tasksWithPhases.length > 0) {
+    avgPhase1 = tasksWithPhases.reduce((a, t) => a + (t.phases?.phase1_duration_secs || 0), 0) / tasksWithPhases.length;
+    avgPhase2 = tasksWithPhases.reduce((a, t) => a + (t.phases?.phase2_duration_secs || 0), 0) / tasksWithPhases.length;
+    avgVerification = tasksWithPhases.reduce((a, t) => a + (t.phases?.verification_duration_secs || 0), 0) / tasksWithPhases.length;
+  }
+
+  const totalPhaseTime = avgPhase1 + avgPhase2 + avgVerification;
+  const phaseBreakdown = {
+    phase1Pct: totalPhaseTime > 0 ? (avgPhase1 / totalPhaseTime) * 100 : 0,
+    phase2Pct: totalPhaseTime > 0 ? (avgPhase2 / totalPhaseTime) * 100 : 0,
+    verificationPct: totalPhaseTime > 0 ? (avgVerification / totalPhaseTime) * 100 : 0,
+  };
+
+  // Complexity
+  const tasksWithComplexity = tasks.filter((t) => t.files_modified !== undefined);
+  const avgFilesModified = tasksWithComplexity.length > 0
+    ? tasksWithComplexity.reduce((a, t) => a + (t.files_modified || 0), 0) / tasksWithComplexity.length
+    : 0;
+  const avgLinesChanged = tasksWithComplexity.length > 0
+    ? tasksWithComplexity.reduce((a, t) => a + (t.lines_changed || 0), 0) / tasksWithComplexity.length
+    : 0;
+
+  // Session stats
+  const totalSessionDuration = sessions.reduce((a, s) => a + s.duration_secs, 0);
+  const gigachadMerges = sessions.reduce((a, s) => a + (s.gigachad_merges || 0), 0);
+
+  // Recent trends (last 10 tasks)
+  const recentTasks = taskList.slice(-10);
+  const recentCompleted = recentTasks.filter((t) => t.status === 'completed');
+  const recentSuccessRate = recentTasks.length > 0
+    ? (recentCompleted.length / recentTasks.length) * 100
+    : 0;
+  const recentDurations = recentCompleted.map((t) => t.duration_secs).filter((d) => d > 0);
+  const recentAvgDuration = recentDurations.length > 0
+    ? recentDurations.reduce((a, b) => a + b, 0) / recentDurations.length
+    : 0;
+
+  // Total cost from sessions (more accurate)
+  const totalCost = sessions.reduce((a, s) => a + (s.total_cost_usd || 0), 0);
+
+  // Category breakdown
+  const categoryBreakdown: Record<string, CategoryStats> = {};
+  for (const task of taskList) {
+    const cat = task.category || 'uncategorized';
+    if (!categoryBreakdown[cat]) {
+      categoryBreakdown[cat] = {
+        tasks: 0,
+        completed: 0,
+        failed: 0,
+        successRate: 0,
+        avgDuration: 0,
+        totalCost: 0,
+      };
+    }
+    categoryBreakdown[cat].tasks++;
+    if (task.status === 'completed') {
+      categoryBreakdown[cat].completed++;
+    } else {
+      categoryBreakdown[cat].failed++;
+    }
+    categoryBreakdown[cat].totalCost += task.cost_usd || 0;
+  }
+
+  // Calculate derived category stats
+  for (const cat of Object.keys(categoryBreakdown)) {
+    const stats = categoryBreakdown[cat];
+    stats.successRate = stats.tasks > 0 ? (stats.completed / stats.tasks) * 100 : 0;
+
+    // Calculate average duration for completed tasks in this category
+    const catDurations = taskList
+      .filter((t) => (t.category || 'uncategorized') === cat && t.status === 'completed' && t.duration_secs > 0)
+      .map((t) => t.duration_secs);
+    stats.avgDuration = catDurations.length > 0
+      ? catDurations.reduce((a, b) => a + b, 0) / catDurations.length
+      : 0;
+  }
+
+  return {
+    totalTasks: taskList.length,
+    completedTasks: completedTasks.length,
+    failedTasks: failedTasks.length,
+    successRate: taskList.length > 0 ? (completedTasks.length / taskList.length) * 100 : 0,
+
+    avgDuration: durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0,
+    medianDuration: calculateMedian(durations),
+    minDuration: durations.length > 0 ? Math.min(...durations) : 0,
+    maxDuration: durations.length > 0 ? Math.max(...durations) : 0,
+    stdDevDuration: calculateStdDev(durations),
+    p90Duration: calculatePercentile(durations, 90),
+    durations,
+
+    totalCost,
+    avgCostPerTask: taskList.length > 0 ? totalCost / taskList.length : 0,
+    avgCostPerSuccessfulTask: completedTasks.length > 0 ? totalCost / completedTasks.length : 0,
+    costs,
+
+    avgIterations: taskList.length > 0
+      ? taskList.reduce((a, t) => a + (t.iterations || 1), 0) / taskList.length
+      : 0,
+    totalIterations: taskList.reduce((a, t) => a + (t.iterations || 1), 0),
+    iterationsDistribution,
+
+    failuresByReason,
+    failuresByPhase,
+
+    avgPhase1Duration: avgPhase1,
+    avgPhase2Duration: avgPhase2,
+    avgVerificationDuration: avgVerification,
+    phaseBreakdown,
+
+    avgFilesModified,
+    avgLinesChanged,
+
+    totalSessions: sessions.length,
+    totalSessionDuration,
+    avgSessionDuration: sessions.length > 0 ? totalSessionDuration / sessions.length : 0,
+    gigachadMerges,
+
+    recentSuccessRate,
+    recentAvgDuration,
+
+    categoryBreakdown,
+  };
+}
+
+function generateSuggestions(analysis: AnalysisResults): string[] {
+  const suggestions: string[] = [];
+
+  // Success rate suggestions
+  if (analysis.successRate < 70) {
+    suggestions.push('Low success rate detected. Consider reviewing task complexity or prompt templates.');
+  }
+  if (analysis.successRate < 50) {
+    suggestions.push('Critical: More than half of tasks are failing. Check error diagnostics for patterns.');
+  }
+
+  // Duration suggestions
+  if (analysis.avgDuration > 600) {
+    // > 10 minutes
+    suggestions.push('Tasks averaging over 10 minutes. Consider breaking tasks into smaller issues.');
+  }
+  if (analysis.stdDevDuration > analysis.avgDuration) {
+    suggestions.push('High duration variance. Some task types may need different handling.');
+  }
+
+  // Iteration suggestions
+  if (analysis.avgIterations > 2) {
+    suggestions.push('High average iterations. Improve test coverage to catch issues earlier.');
+  }
+
+  // Cost suggestions
+  if (analysis.avgCostPerTask > 0.5) {
+    suggestions.push('High average cost per task. Consider using smaller models for simpler tasks.');
+  }
+
+  // Failure pattern suggestions
+  const topFailure = Object.entries(analysis.failuresByReason)
+    .sort(([, a], [, b]) => b - a)[0];
+  if (topFailure && topFailure[1] >= 3) {
+    suggestions.push(`Most common failure: "${topFailure[0]}" (${topFailure[1]} times). Address this root cause.`);
+  }
+
+  // Phase timing suggestions
+  if (analysis.phaseBreakdown.verificationPct > 40) {
+    suggestions.push('Verification takes >40% of task time. Consider optimizing test suite.');
+  }
+
+  // Trend suggestions
+  if (analysis.recentSuccessRate < analysis.successRate - 10) {
+    suggestions.push('Recent success rate is declining. Review recent changes to templates or workflow.');
+  }
+
+  // GigaChad mode suggestions
+  if (analysis.gigachadMerges > 0 && analysis.successRate < 90) {
+    suggestions.push('GigaChad mode active with <90% success rate. Consider disabling until reliability improves.');
+  }
+
+  return suggestions;
+}
+
+function printInsights(analysis: AnalysisResults, _chadgiDir: string): void {
+  console.log(`${colors.purple}${colors.bold}`);
+  console.log('==========================================================');
+  console.log('               CHADGI PERFORMANCE INSIGHTS                 ');
+  console.log('==========================================================');
+  console.log(`${colors.reset}`);
+
+  // Overview Section
+  console.log(`${colors.cyan}${colors.bold}Overview${colors.reset}`);
+  console.log(`  Total Tasks:      ${analysis.totalTasks}`);
+  console.log(`  Completed:        ${colors.green}${analysis.completedTasks}${colors.reset}`);
+  console.log(`  Failed:           ${colors.red}${analysis.failedTasks}${colors.reset}`);
+  const successColor = analysis.successRate >= 80 ? colors.green : analysis.successRate >= 50 ? colors.yellow : colors.red;
+  console.log(`  Success Rate:     ${successColor}${analysis.successRate.toFixed(1)}%${colors.reset}`);
+  console.log(`  Total Sessions:   ${analysis.totalSessions}`);
+  if (analysis.gigachadMerges > 0) {
+    console.log(`  ${colors.purple}GigaChad Merges: ${analysis.gigachadMerges}${colors.reset}`);
+  }
+  console.log('');
+
+  // Duration Analysis
+  console.log(`${colors.cyan}${colors.bold}Duration Analysis${colors.reset}`);
+  console.log(`  Average:          ${formatDuration(analysis.avgDuration)}`);
+  console.log(`  Median:           ${formatDuration(analysis.medianDuration)}`);
+  console.log(`  Min:              ${formatDuration(analysis.minDuration)}`);
+  console.log(`  Max:              ${formatDuration(analysis.maxDuration)}`);
+  console.log(`  Std Dev:          ${formatDuration(analysis.stdDevDuration)}`);
+  console.log(`  P90:              ${formatDuration(analysis.p90Duration)}`);
+  console.log('');
+
+  // Duration distribution histogram
+  if (analysis.durations.length > 0) {
+    console.log(`${colors.dim}Duration Distribution:${colors.reset}`);
+    const histogram = generateHistogram(analysis.durations, 5, 15);
+    histogram.forEach((line) => console.log(line));
+    console.log('');
+  }
+
+  // Cost Analysis
+  console.log(`${colors.cyan}${colors.bold}Cost Analysis${colors.reset}`);
+  console.log(`  Total Cost:       $${analysis.totalCost.toFixed(4)}`);
+  console.log(`  Avg per Task:     $${analysis.avgCostPerTask.toFixed(4)}`);
+  console.log(`  Avg per Success:  $${analysis.avgCostPerSuccessfulTask.toFixed(4)}`);
+  if (analysis.totalSessionDuration > 0) {
+    const costPerMinute = (analysis.totalCost / analysis.totalSessionDuration) * 60;
+    console.log(`  Cost per Minute:  $${costPerMinute.toFixed(4)}`);
+  }
+  console.log('');
+
+  // Iteration Analysis
+  console.log(`${colors.cyan}${colors.bold}Iteration Analysis${colors.reset}`);
+  console.log(`  Avg Iterations:   ${analysis.avgIterations.toFixed(1)}`);
+  console.log(`  Total Iterations: ${analysis.totalIterations}`);
+  if (Object.keys(analysis.iterationsDistribution).length > 0) {
+    console.log(`  Distribution:`);
+    const sorted = Object.entries(analysis.iterationsDistribution)
+      .sort(([a], [b]) => Number(a) - Number(b));
+    for (const [iter, count] of sorted) {
+      const pct = ((count / analysis.totalTasks) * 100).toFixed(0);
+      console.log(`    ${iter} iteration(s): ${count} tasks (${pct}%)`);
+    }
+  }
+  console.log('');
+
+  // Phase Timing (if available)
+  if (analysis.avgPhase1Duration > 0 || analysis.avgPhase2Duration > 0) {
+    console.log(`${colors.cyan}${colors.bold}Phase Timing${colors.reset}`);
+    console.log(`  Phase 1 (Impl):   ${formatDuration(analysis.avgPhase1Duration)} (${analysis.phaseBreakdown.phase1Pct.toFixed(0)}%)`);
+    console.log(`  Phase 2 (PR):     ${formatDuration(analysis.avgPhase2Duration)} (${analysis.phaseBreakdown.phase2Pct.toFixed(0)}%)`);
+    console.log(`  Verification:     ${formatDuration(analysis.avgVerificationDuration)} (${analysis.phaseBreakdown.verificationPct.toFixed(0)}%)`);
+    console.log('');
+  }
+
+  // Failure Analysis
+  if (analysis.failedTasks > 0) {
+    console.log(`${colors.cyan}${colors.bold}Failure Analysis${colors.reset}`);
+    if (Object.keys(analysis.failuresByReason).length > 0) {
+      console.log(`  By Reason:`);
+      const sorted = Object.entries(analysis.failuresByReason)
+        .sort(([, a], [, b]) => b - a);
+      for (const [reason, count] of sorted) {
+        const pct = ((count / analysis.failedTasks) * 100).toFixed(0);
+        console.log(`    ${colors.red}${reason}${colors.reset}: ${count} (${pct}%)`);
+      }
+    }
+    if (Object.keys(analysis.failuresByPhase).length > 0) {
+      console.log(`  By Phase:`);
+      for (const [phase, count] of Object.entries(analysis.failuresByPhase)) {
+        const pct = ((count / analysis.failedTasks) * 100).toFixed(0);
+        console.log(`    ${phase}: ${count} (${pct}%)`);
+      }
+    }
+    console.log('');
+  }
+
+  // Complexity Metrics (if available)
+  if (analysis.avgFilesModified > 0) {
+    console.log(`${colors.cyan}${colors.bold}Complexity Metrics${colors.reset}`);
+    console.log(`  Avg Files Modified: ${analysis.avgFilesModified.toFixed(1)}`);
+    console.log(`  Avg Lines Changed:  ${analysis.avgLinesChanged.toFixed(0)}`);
+    console.log('');
+  }
+
+  // Category Breakdown
+  const categoryKeys = Object.keys(analysis.categoryBreakdown);
+  if (categoryKeys.length > 0 && !(categoryKeys.length === 1 && categoryKeys[0] === 'uncategorized')) {
+    console.log(`${colors.cyan}${colors.bold}Category Breakdown${colors.reset}`);
+    // Sort categories by task count descending
+    const sortedCategories = categoryKeys
+      .map((cat) => ({ cat, stats: analysis.categoryBreakdown[cat] }))
+      .sort((a, b) => b.stats.tasks - a.stats.tasks);
+
+    for (const { cat, stats } of sortedCategories) {
+      const catSuccessColor = stats.successRate >= 80 ? colors.green : stats.successRate >= 50 ? colors.yellow : colors.red;
+      const durationStr = stats.avgDuration > 0 ? formatDuration(stats.avgDuration) : 'N/A';
+      console.log(`  ${colors.bold}${cat}${colors.reset}: ${stats.tasks} tasks, ${catSuccessColor}${stats.successRate.toFixed(0)}% success${colors.reset}, avg ${durationStr}`);
+    }
+    console.log('');
+  }
+
+  // Recent Trends
+  console.log(`${colors.cyan}${colors.bold}Recent Trends (Last 10 Tasks)${colors.reset}`);
+  const trendColor = analysis.recentSuccessRate >= analysis.successRate
+    ? colors.green
+    : colors.yellow;
+  console.log(`  Success Rate:     ${trendColor}${analysis.recentSuccessRate.toFixed(1)}%${colors.reset}`);
+  console.log(`  Avg Duration:     ${formatDuration(analysis.recentAvgDuration)}`);
+  console.log('');
+
+  // Suggestions
+  const suggestions = generateSuggestions(analysis);
+  if (suggestions.length > 0) {
+    console.log(`${colors.yellow}${colors.bold}Optimization Suggestions${colors.reset}`);
+    for (const suggestion of suggestions) {
+      console.log(`  ${colors.yellow}*${colors.reset} ${suggestion}`);
+    }
+    console.log('');
+  }
+
+  console.log(`${colors.purple}${colors.bold}==========================================================`);
+  console.log('               Chad does what Chad wants.');
+  console.log(`==========================================================${colors.reset}`);
+}
+
+/**
+ * Insights command handler using middleware pattern.
+ *
+ * Note how the handler is now focused purely on business logic:
+ * - No try/catch needed (handled by withErrorHandler)
+ * - No config path resolution (handled by withDirectory)
+ * - No directory validation (handled by withDirectoryValidation)
+ * - JSON output is handled automatically when result.data is returned
+ */
+async function insightsHandler(
+  ctx: DirectoryContext<InsightsOptions>
+): Promise<CommandResult> {
+  const { chadgiDir, options } = ctx;
+
+  // Load data
+  let { sessions, tasks } = loadInsightsData(chadgiDir, options.days);
+
+  if (sessions.length === 0 && tasks.length === 0) {
+    console.log('No performance data found.');
+    console.log(`Looking in: ${chadgiDir}`);
+    console.log('\nRun `chadgi start` to begin collecting performance metrics.');
+    return { success: true };
+  }
+
+  // Filter by category if specified
+  if (options.category) {
+    const categoryFilter = options.category.toLowerCase();
+    tasks = tasks.filter((t) => t.category?.toLowerCase() === categoryFilter);
+    if (tasks.length === 0) {
+      console.log(`No tasks found with category: ${options.category}`);
+      console.log('Available categories can be viewed by running `chadgi insights` without the --category flag.');
+      return { success: true };
+    }
+    console.log(`${colors.dim}Filtering by category: ${options.category}${colors.reset}\n`);
+  }
+
+  // Analyze data
+  const analysis = analyzeData(sessions, tasks);
+
+  // Export if requested
+  if (options.export) {
+    const exportData = {
+      generated_at: new Date().toISOString(),
+      analysis,
+      sessions,
+      tasks,
+    };
+    writeFileSync(options.export, JSON.stringify(exportData, null, 2));
+    console.log(`Metrics exported to: ${options.export}`);
+    return { success: true };
+  }
+
+  // Output as JSON if requested
+  if (options.json) {
+    return { data: analysis };
+  }
+
+  // Display formatted insights
+  printInsights(analysis, chadgiDir);
+
+  return { success: true };
+}
+
+/**
+ * Insights command with middleware applied.
+ *
+ * The middleware chain:
+ * 1. withTiming - tracks execution time (added automatically)
+ * 2. withErrorHandler - catches and formats errors (added automatically)
+ * 3. withJsonOutput - handles JSON serialization (added automatically)
+ * 4. withDirectory - resolves chadgiDir and configPath
+ * 5. withDirectoryValidation - ensures .chadgi directory exists
+ */
+export const insightsMiddleware = withCommand<InsightsOptions, DirectoryContext<InsightsOptions>>(
+  [withDirectory, withDirectoryValidation] as any,
+  insightsHandler
+);

--- a/src/validate-middleware.ts
+++ b/src/validate-middleware.ts
@@ -1,0 +1,862 @@
+/**
+ * Validate command implementation using the middleware system.
+ *
+ * This is a refactored version of validate.ts that demonstrates the middleware
+ * pattern for reducing boilerplate.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { maskSecrets, setMaskingDisabled } from './utils/secrets.js';
+import {
+  parseYamlValue,
+  parseYamlNested,
+  parseEnvOverrides,
+  DEFAULT_ENV_PREFIX,
+} from './utils/config.js';
+import { checkMigrations, CURRENT_CONFIG_VERSION, DEFAULT_CONFIG_VERSION } from './migrations/index.js';
+import { debugLog, startTiming } from './utils/debug.js';
+import { colors } from './utils/colors.js';
+
+// Import middleware utilities
+import {
+  withCommand,
+  withDirectory,
+  type DirectoryContext,
+  type CommandResult,
+} from './utils/index.js';
+
+// Import shared types
+import type { BaseCommandOptions } from './types/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Validate command options.
+ */
+interface ValidateOptions extends BaseCommandOptions {
+  quiet?: boolean;
+  notifyTest?: boolean;
+  strict?: boolean;
+  showMerged?: boolean;
+  mask?: boolean;  // --no-mask flag sets this to false
+  verbose?: boolean;  // Show env var sources
+  envPrefix?: string;  // Custom env var prefix (default: CHADGI_)
+}
+
+interface ValidationResult {
+  name: string;
+  status: 'ok' | 'warning' | 'error';
+  message: string;
+}
+
+function checkCommand(command: string): boolean {
+  try {
+    execSync(`which ${command}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getCommandVersion(command: string): string | null {
+  try {
+    return execSync(`${command} --version`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+      .split('\n')[0]
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+// Config inheritance support
+
+interface ConfigChainResult {
+  configFiles: string[];
+  error: string | null;
+}
+
+function getExtendsPath(configContent: string): string | null {
+  // Check for 'extends' field first, then 'base_config'
+  let extendsValue = parseYamlValue(configContent, 'extends');
+  if (!extendsValue) {
+    extendsValue = parseYamlValue(configContent, 'base_config');
+  }
+  return extendsValue;
+}
+
+function resolveConfigPathRelative(baseDir: string, configPath: string): string {
+  if (!configPath) return '';
+  if (configPath.startsWith('/')) {
+    return configPath; // Absolute path
+  }
+  return join(baseDir, configPath); // Relative path
+}
+
+function loadConfigChain(configPath: string, visited: Set<string> = new Set()): ConfigChainResult {
+  const resolvedPath = resolve(configPath);
+
+  // Cycle detection
+  if (visited.has(resolvedPath)) {
+    return {
+      configFiles: [],
+      error: `Circular inheritance detected: ${resolvedPath} was already visited`
+    };
+  }
+
+  // Check if file exists
+  if (!existsSync(resolvedPath)) {
+    return {
+      configFiles: [],
+      error: `Config file not found: ${resolvedPath}`
+    };
+  }
+
+  visited.add(resolvedPath);
+
+  const configContent = readFileSync(resolvedPath, 'utf-8');
+  const extendsValue = getExtendsPath(configContent);
+
+  if (extendsValue) {
+    // Resolve the base config path relative to current config's directory
+    const baseConfigPath = resolveConfigPathRelative(dirname(resolvedPath), extendsValue);
+
+    // Recursively load the base config
+    const baseResult = loadConfigChain(baseConfigPath, visited);
+    if (baseResult.error) {
+      return {
+        configFiles: [],
+        error: `${baseResult.error}\n  Referenced from: ${resolvedPath}`
+      };
+    }
+
+    // Return base configs first, then current config
+    return {
+      configFiles: [...baseResult.configFiles, resolvedPath],
+      error: null
+    };
+  }
+
+  // No inheritance, just return this config
+  return {
+    configFiles: [resolvedPath],
+    error: null
+  };
+}
+
+interface MergedConfig {
+  [key: string]: string | MergedConfig | null;
+}
+
+function mergeConfigs(configFiles: string[]): MergedConfig {
+  const merged: MergedConfig = {};
+
+  for (const configFile of configFiles) {
+    const content = readFileSync(configFile, 'utf-8');
+    const lines = content.split('\n');
+
+    let currentSection: string | null = null;
+    let currentSubsection: string | null = null;
+
+    for (const line of lines) {
+      // Skip empty lines and comments
+      if (!line.trim() || line.trim().startsWith('#')) continue;
+
+      // Top-level key (no indentation)
+      const topLevelMatch = line.match(/^([a-z_]+):\s*(.*)$/);
+      if (topLevelMatch) {
+        currentSection = topLevelMatch[1];
+        currentSubsection = null;
+        const value = topLevelMatch[2].replace(/["']/g, '').replace(/#.*$/, '').trim();
+        if (value && currentSection !== 'extends' && currentSection !== 'base_config') {
+          merged[currentSection] = value;
+        } else if (!value && currentSection !== 'extends' && currentSection !== 'base_config') {
+          // Object value - initialize if not exists
+          if (!merged[currentSection] || typeof merged[currentSection] !== 'object') {
+            merged[currentSection] = {};
+          }
+        }
+        continue;
+      }
+
+      // First-level nested key (2 spaces)
+      const nestedMatch = line.match(/^  ([a-z_]+):\s*(.*)$/);
+      if (nestedMatch && currentSection) {
+        currentSubsection = nestedMatch[1];
+        const value = nestedMatch[2].replace(/["']/g, '').replace(/#.*$/, '').trim();
+        if (typeof merged[currentSection] !== 'object' || merged[currentSection] === null) {
+          merged[currentSection] = {};
+        }
+        if (value) {
+          (merged[currentSection] as MergedConfig)[currentSubsection] = value;
+        } else {
+          // Object value
+          if (!(merged[currentSection] as MergedConfig)[currentSubsection] ||
+              typeof (merged[currentSection] as MergedConfig)[currentSubsection] !== 'object') {
+            (merged[currentSection] as MergedConfig)[currentSubsection] = {};
+          }
+        }
+        continue;
+      }
+
+      // Second-level nested key (4 spaces)
+      const deepNestedMatch = line.match(/^    ([a-z_]+):\s*(.*)$/);
+      if (deepNestedMatch && currentSection && currentSubsection) {
+        const key = deepNestedMatch[1];
+        const value = deepNestedMatch[2].replace(/["']/g, '').replace(/#.*$/, '').trim();
+        if (typeof merged[currentSection] === 'object' && merged[currentSection] !== null) {
+          const section = merged[currentSection] as MergedConfig;
+          if (typeof section[currentSubsection] !== 'object' || section[currentSubsection] === null) {
+            section[currentSubsection] = {};
+          }
+          (section[currentSubsection] as MergedConfig)[key] = value || null;
+        }
+      }
+    }
+  }
+
+  return merged;
+}
+
+function formatMergedConfig(merged: MergedConfig, indent: number = 0): string {
+  const lines: string[] = [];
+  const prefix = '  '.repeat(indent);
+
+  for (const [key, value] of Object.entries(merged)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === 'object') {
+      lines.push(`${prefix}${key}:`);
+      lines.push(formatMergedConfig(value as MergedConfig, indent + 1));
+    } else {
+      lines.push(`${prefix}${key}: ${value}`);
+    }
+  }
+
+  return lines.filter(l => l.trim()).join('\n');
+}
+
+// Valid template variables as documented in README.md
+const VALID_TEMPLATE_VARIABLES = new Set([
+  'ISSUE_NUMBER',
+  'ISSUE_TITLE',
+  'ISSUE_URL',
+  'ISSUE_BODY',
+  'BRANCH_NAME',
+  'BASE_BRANCH',
+  'REPO',
+  'REPO_OWNER',
+  'PROJECT_NUMBER',
+  'READY_COLUMN',
+  'COMPLETION_PROMISE',
+  'TEST_COMMAND',
+  'BUILD_COMMAND',
+  // Additional internal variables used in templates
+  'CHAD_TAGLINE',
+  'CHAD_LABEL',
+  'CHAD_FOOTER',
+  'ISSUE_PREFIX',
+  'EXISTING_ISSUES',
+  'GITHUB_USERNAME',
+]);
+
+interface TemplateVariableMatch {
+  variable: string;
+  line: number;
+  column: number;
+}
+
+function extractTemplateVariables(content: string): TemplateVariableMatch[] {
+  const matches: TemplateVariableMatch[] = [];
+  const lines = content.split('\n');
+  const variablePattern = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    let match;
+    while ((match = variablePattern.exec(line)) !== null) {
+      matches.push({
+        variable: match[1],
+        line: lineIndex + 1,
+        column: match.index + 1,
+      });
+    }
+  }
+
+  return matches;
+}
+
+function parseCustomVariables(configContent: string): string[] {
+  const customVars: string[] = [];
+  const lines = configContent.split('\n');
+  let inCustomVars = false;
+
+  for (const line of lines) {
+    if (line.match(/^custom_template_variables:/)) {
+      inCustomVars = true;
+      continue;
+    }
+    if (inCustomVars && line.match(/^[a-z]/)) {
+      inCustomVars = false;
+    }
+    if (inCustomVars && line.match(/^\s+-\s*/)) {
+      const varName = line.replace(/^\s+-\s*/, '').replace(/["']/g, '').trim();
+      if (varName) {
+        customVars.push(varName);
+      }
+    }
+  }
+
+  return customVars;
+}
+
+export interface TemplateValidationResult {
+  templatePath: string;
+  unknownVariables: TemplateVariableMatch[];
+}
+
+export function validateTemplateVariables(
+  templatePath: string,
+  customVariables: string[] = []
+): TemplateValidationResult {
+  const content = readFileSync(templatePath, 'utf-8');
+  const matches = extractTemplateVariables(content);
+  const allValidVariables = new Set([...VALID_TEMPLATE_VARIABLES, ...customVariables]);
+
+  const unknownVariables = matches.filter(m => !allValidVariables.has(m.variable));
+
+  return {
+    templatePath,
+    unknownVariables,
+  };
+}
+
+/**
+ * Validate command handler using middleware pattern.
+ *
+ * Note how the handler receives context with pre-loaded paths:
+ * - No config path resolution needed
+ * - No try/catch boilerplate for top-level errors
+ */
+async function validateHandler(
+  ctx: DirectoryContext<ValidateOptions>
+): Promise<CommandResult> {
+  const { chadgiDir, configPath, options } = ctx;
+  const endValidateTiming = startTiming('validate');
+
+  // Handle --no-mask flag (Commander sets mask=false when --no-mask is used)
+  const noMask = options.mask === false;
+  if (noMask) {
+    setMaskingDisabled(true);
+    console.log('\x1b[33mWARNING: Secret masking is DISABLED. Sensitive data may be exposed in output.\x1b[0m\n');
+  }
+
+  const results: ValidationResult[] = [];
+  debugLog('Starting validation', { configPath, cwd: ctx.cwd, options: { ...options, verbose: undefined } });
+  const quiet = options.quiet || false;
+
+  if (!quiet) {
+    console.log('Validating ChadGI configuration...\n');
+    console.log('Checking dependencies:\n');
+  }
+
+  // Check required commands
+  const requiredCommands = ['claude', 'gh', 'jq', 'git'];
+
+  for (const cmd of requiredCommands) {
+    if (checkCommand(cmd)) {
+      const version = getCommandVersion(cmd);
+      results.push({
+        name: cmd,
+        status: 'ok',
+        message: version || 'installed'
+      });
+    } else {
+      results.push({
+        name: cmd,
+        status: 'error',
+        message: 'not found'
+      });
+    }
+  }
+
+  // Check optional commands
+  const optionalCommands = ['perl'];
+  for (const cmd of optionalCommands) {
+    if (checkCommand(cmd)) {
+      results.push({
+        name: cmd,
+        status: 'ok',
+        message: 'installed (optional)'
+      });
+    } else {
+      results.push({
+        name: cmd,
+        status: 'warning',
+        message: 'not found (optional, used for multiline templates)'
+      });
+    }
+  }
+
+  // Print dependency results
+  if (!quiet) {
+    for (const result of results) {
+      const icon = result.status === 'ok' ? '+' : result.status === 'warning' ? '!' : 'x';
+      const color = result.status === 'ok' ? '\x1b[32m' : result.status === 'warning' ? '\x1b[33m' : '\x1b[31m';
+      console.log(`${color}${icon}\x1b[0m ${result.name}: ${result.message}`);
+    }
+    console.log('');
+  }
+
+  // Check GitHub CLI authentication
+  if (!quiet) {
+    console.log('Checking GitHub CLI authentication:\n');
+  }
+
+  try {
+    execSync('gh auth status', { stdio: 'pipe' });
+    results.push({
+      name: 'gh auth',
+      status: 'ok',
+      message: 'authenticated'
+    });
+    if (!quiet) {
+      console.log('\x1b[32m+\x1b[0m GitHub CLI authenticated');
+    }
+  } catch {
+    results.push({
+      name: 'gh auth',
+      status: 'error',
+      message: 'not authenticated'
+    });
+    if (!quiet) {
+      console.log('\x1b[31mx\x1b[0m GitHub CLI not authenticated');
+      console.log('  Run: gh auth login');
+    }
+  }
+
+  if (!quiet) {
+    console.log('');
+    console.log('Checking configuration:\n');
+  }
+
+  // Check config file exists and validate inheritance chain
+  if (existsSync(configPath)) {
+    results.push({
+      name: 'config file',
+      status: 'ok',
+      message: configPath
+    });
+    if (!quiet) {
+      console.log(`\x1b[32m+\x1b[0m Config file found: ${configPath}`);
+    }
+
+    // Check config version and pending migrations
+    const migrationCheck = checkMigrations(configPath);
+    const currentVersion = migrationCheck.currentVersion || `${DEFAULT_CONFIG_VERSION} (implicit)`;
+
+    if (migrationCheck.needsMigration) {
+      results.push({
+        name: 'config_version',
+        status: 'warning',
+        message: `${currentVersion} -> ${CURRENT_CONFIG_VERSION} (migration available)`
+      });
+      if (!quiet) {
+        console.log(`\x1b[33m!\x1b[0m Config version: ${currentVersion} (migration available to ${CURRENT_CONFIG_VERSION})`);
+        console.log(`    Run 'chadgi config migrate' to update`);
+      }
+    } else {
+      results.push({
+        name: 'config_version',
+        status: 'ok',
+        message: CURRENT_CONFIG_VERSION
+      });
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Config version: ${CURRENT_CONFIG_VERSION}`);
+      }
+    }
+
+    // Load and validate config inheritance chain
+    const chainResult = loadConfigChain(configPath);
+    let configFiles: string[] = [];
+
+    if (chainResult.error) {
+      results.push({
+        name: 'config inheritance',
+        status: 'error',
+        message: chainResult.error
+      });
+      if (!quiet) {
+        console.log(`\x1b[31mx\x1b[0m Config inheritance error:`);
+        console.log(`    ${chainResult.error.replace(/\n/g, '\n    ')}`);
+      }
+    } else {
+      configFiles = chainResult.configFiles;
+
+      if (configFiles.length > 1) {
+        results.push({
+          name: 'config inheritance',
+          status: 'ok',
+          message: `${configFiles.length} config files in chain`
+        });
+        if (!quiet) {
+          console.log(`\x1b[32m+\x1b[0m Config inheritance chain (${configFiles.length} files):`);
+          for (const cfg of configFiles) {
+            console.log(`    - ${cfg}`);
+          }
+        }
+      }
+    }
+
+    // Show merged config if requested
+    if (options.showMerged && configFiles.length > 0) {
+      console.log('');
+      console.log('Merged configuration:\n');
+      const merged = mergeConfigs(configFiles);
+      console.log(formatMergedConfig(merged));
+      console.log('');
+    }
+
+    // Parse and validate config (using merged values from all config files)
+    // For simplicity, read the primary config for now
+    const configContent = readFileSync(configPath, 'utf-8');
+
+    // Check required fields (using merged config chain)
+    let repo: string | null = null;
+    let projectNumber: string | null = null;
+    for (const cfg of configFiles) {
+      const content = readFileSync(cfg, 'utf-8');
+      const cfgRepo = parseYamlNested(content, 'github', 'repo');
+      const cfgProjectNumber = parseYamlNested(content, 'github', 'project_number');
+      if (cfgRepo) repo = cfgRepo;
+      if (cfgProjectNumber) projectNumber = cfgProjectNumber;
+    }
+
+    if (repo && repo !== 'owner/repo') {
+      results.push({
+        name: 'github.repo',
+        status: 'ok',
+        message: repo
+      });
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Repository: ${repo}`);
+      }
+    } else {
+      results.push({
+        name: 'github.repo',
+        status: 'warning',
+        message: 'not configured (using default)'
+      });
+      if (!quiet) {
+        console.log('\x1b[33m!\x1b[0m Repository not configured (still using default owner/repo)');
+      }
+    }
+
+    if (projectNumber) {
+      results.push({
+        name: 'github.project_number',
+        status: 'ok',
+        message: `Project #${projectNumber}`
+      });
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Project number: ${projectNumber}`);
+      }
+    } else {
+      results.push({
+        name: 'github.project_number',
+        status: 'warning',
+        message: 'not configured'
+      });
+      if (!quiet) {
+        console.log('\x1b[33m!\x1b[0m Project number not configured');
+      }
+    }
+
+    // Check template files
+    const promptTemplate = parseYamlValue(configContent, 'prompt_template') || './chadgi-task.md';
+    const generateTemplate = parseYamlValue(configContent, 'generate_template') || './chadgi-generate-task.md';
+
+    const templatePath = promptTemplate.startsWith('/') ? promptTemplate : join(chadgiDir, promptTemplate);
+    const generateTemplatePath = generateTemplate.startsWith('/') ? generateTemplate : join(chadgiDir, generateTemplate);
+
+    if (existsSync(templatePath)) {
+      results.push({
+        name: 'prompt_template',
+        status: 'ok',
+        message: templatePath
+      });
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Task template found`);
+      }
+    } else {
+      results.push({
+        name: 'prompt_template',
+        status: 'error',
+        message: `not found: ${templatePath}`
+      });
+      if (!quiet) {
+        console.log(`\x1b[31mx\x1b[0m Task template not found: ${templatePath}`);
+      }
+    }
+
+    if (existsSync(generateTemplatePath)) {
+      results.push({
+        name: 'generate_template',
+        status: 'ok',
+        message: generateTemplatePath
+      });
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Generate template found`);
+      }
+    } else {
+      results.push({
+        name: 'generate_template',
+        status: 'error',
+        message: `not found: ${generateTemplatePath}`
+      });
+      if (!quiet) {
+        console.log(`\x1b[31mx\x1b[0m Generate template not found: ${generateTemplatePath}`);
+      }
+    }
+
+    // Validate template variables
+    if (!quiet) {
+      console.log('');
+      console.log('Checking template variables:\n');
+    }
+
+    const customVariables = parseCustomVariables(configContent);
+    const templatesToValidate: string[] = [];
+
+    if (existsSync(templatePath)) {
+      templatesToValidate.push(templatePath);
+    }
+    if (existsSync(generateTemplatePath)) {
+      templatesToValidate.push(generateTemplatePath);
+    }
+
+    let hasUnknownVariables = false;
+    for (const tmplPath of templatesToValidate) {
+      const validation = validateTemplateVariables(tmplPath, customVariables);
+      const templateBasename = tmplPath.split('/').pop() || tmplPath;
+
+      if (validation.unknownVariables.length === 0) {
+        results.push({
+          name: `template vars: ${templateBasename}`,
+          status: 'ok',
+          message: 'all variables valid'
+        });
+        if (!quiet) {
+          console.log(`\x1b[32m+\x1b[0m ${templateBasename}: all variables valid`);
+        }
+      } else {
+        hasUnknownVariables = true;
+        // In strict mode, unknown variables are errors; otherwise warnings
+        const status = options.strict ? 'error' : 'warning';
+        const icon = options.strict ? 'x' : '!';
+        const color = options.strict ? '\x1b[31m' : '\x1b[33m';
+
+        results.push({
+          name: `template vars: ${templateBasename}`,
+          status,
+          message: `${validation.unknownVariables.length} unknown variable(s)`
+        });
+
+        if (!quiet) {
+          console.log(`${color}${icon}\x1b[0m ${templateBasename}: ${validation.unknownVariables.length} unknown variable(s)`);
+          for (const v of validation.unknownVariables) {
+            console.log(`    Line ${v.line}, col ${v.column}: {{${v.variable}}} (unknown)`);
+          }
+        }
+      }
+    }
+
+    if (hasUnknownVariables && !quiet) {
+      console.log('');
+      if (options.strict) {
+        console.log('\x1b[33m!\x1b[0m Unknown variables cause errors in --strict mode');
+      } else {
+        console.log('\x1b[33m!\x1b[0m Tip: Add custom variables to config with custom_template_variables:');
+        console.log('    custom_template_variables:');
+        console.log('      - MY_CUSTOM_VAR');
+      }
+    }
+
+    // Check environment variable overrides (verbose mode)
+    const envPrefix = options.envPrefix || DEFAULT_ENV_PREFIX;
+    const envOverrides = parseEnvOverrides(envPrefix);
+
+    if (envOverrides.length > 0) {
+      if (!quiet) {
+        console.log('');
+        console.log('Checking environment variable overrides:\n');
+      }
+
+      results.push({
+        name: 'env overrides',
+        status: 'ok',
+        message: `${envOverrides.length} override(s) active`
+      });
+
+      if (!quiet) {
+        console.log(`\x1b[32m+\x1b[0m Environment prefix: ${envPrefix}`);
+        console.log(`\x1b[32m+\x1b[0m Active overrides: ${envOverrides.length}`);
+
+        if (options.verbose) {
+          for (const override of envOverrides) {
+            // Mask sensitive values like tokens
+            const isSensitive = override.configPath.includes('token') ||
+                               override.configPath.includes('secret') ||
+                               override.configPath.includes('password') ||
+                               override.configPath.includes('key');
+            const displayValue = isSensitive ? maskSecrets(override.rawValue) : override.rawValue;
+            console.log(`    ${override.envVar} -> ${override.configPath} = ${displayValue}`);
+          }
+        }
+      }
+    } else if (options.verbose && !quiet) {
+      console.log('');
+      console.log('Checking environment variable overrides:\n');
+      console.log(`\x1b[33m!\x1b[0m No ${envPrefix}* environment variables detected`);
+      console.log('    Tip: Use environment variables to override config values:');
+      console.log(`    ${envPrefix}GITHUB__REPO=owner/repo`);
+      console.log(`    ${envPrefix}ITERATION__MAX_ITERATIONS=10`);
+    }
+
+  } else {
+    results.push({
+      name: 'config file',
+      status: 'error',
+      message: `not found: ${configPath}`
+    });
+    if (!quiet) {
+      console.log(`\x1b[31mx\x1b[0m Config file not found: ${configPath}`);
+      console.log('  Run: chadgi init');
+    }
+  }
+
+  // Check if in a git repository
+  try {
+    execSync('git rev-parse --git-dir', { stdio: 'pipe', cwd: ctx.cwd });
+    results.push({
+      name: 'git repository',
+      status: 'ok',
+      message: 'in git repository'
+    });
+    if (!quiet) {
+      console.log('\x1b[32m+\x1b[0m In git repository');
+    }
+  } catch {
+    results.push({
+      name: 'git repository',
+      status: 'warning',
+      message: 'not in git repository'
+    });
+    if (!quiet) {
+      console.log('\x1b[33m!\x1b[0m Not in a git repository');
+    }
+  }
+
+  // Test webhook notifications if requested
+  if (options.notifyTest) {
+    if (!quiet) {
+      console.log('\nTesting webhook notifications:\n');
+    }
+
+    // Get the script directory from this module's location
+    const scriptDir = join(__dirname, '..', 'scripts');
+    const testScript = `
+      source "${scriptDir}/chadgi.sh" 2>/dev/null || true
+      CONFIG_FILE="${configPath}"
+      load_config 2>/dev/null || true
+      test_webhook_connectivity
+    `;
+
+    try {
+      execSync(`bash -c '${testScript}'`, {
+        stdio: quiet ? 'pipe' : 'inherit',
+        env: {
+          ...process.env,
+          CHADGI_DIR: chadgiDir,
+          CONFIG_FILE: configPath
+        }
+      });
+      results.push({
+        name: 'webhooks',
+        status: 'ok',
+        message: 'connectivity test passed'
+      });
+    } catch {
+      results.push({
+        name: 'webhooks',
+        status: 'warning',
+        message: 'connectivity test failed or no webhooks configured'
+      });
+      if (!quiet) {
+        console.log('\x1b[33m!\x1b[0m Webhook test failed or no webhooks configured');
+      }
+    }
+  }
+
+  // Summary
+  const errors = results.filter(r => r.status === 'error');
+  const warnings = results.filter(r => r.status === 'warning');
+
+  if (!quiet) {
+    console.log('\n---');
+    console.log(`Validation complete: ${errors.length} error(s), ${warnings.length} warning(s)`);
+
+    if (errors.length > 0) {
+      console.log('\nPlease fix the errors above before running ChadGI.');
+    } else if (warnings.length > 0) {
+      console.log('\nChadGI can run with warnings, but consider fixing them for optimal operation.');
+    } else {
+      console.log('\nAll checks passed! Run `chadgi start` to begin.');
+    }
+  }
+
+  debugLog('Validation complete', { errors: errors.length, warnings: warnings.length });
+  endValidateTiming();
+
+  // Return validation result (for JSON output and exit code)
+  const isValid = errors.length === 0;
+
+  if (options.json) {
+    return {
+      data: {
+        valid: isValid,
+        results,
+        summary: {
+          total: results.length,
+          passed: results.filter(r => r.status === 'ok').length,
+          warnings: warnings.length,
+          errors: errors.length,
+        }
+      }
+    };
+  }
+
+  // Return success status - the exit code is handled by the caller
+  return { success: isValid, data: isValid };
+}
+
+/**
+ * Validate command with middleware applied.
+ *
+ * The middleware chain:
+ * 1. withTiming - tracks execution time (added automatically)
+ * 2. withErrorHandler - catches and formats errors (added automatically)
+ * 3. withJsonOutput - handles JSON serialization (added automatically)
+ * 4. withDirectory - resolves chadgiDir and configPath
+ *
+ * Note: This command does NOT use withDirectoryValidation because it
+ * should be able to report that the .chadgi directory doesn't exist.
+ */
+export const validateMiddleware = withCommand<ValidateOptions, DirectoryContext<ValidateOptions>>(
+  [withDirectory] as any,
+  validateHandler
+);

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -63,7 +63,9 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 3: CLI imports doctor module"
 
-if grep -q "import { doctor }" "$PROJECT_ROOT/src/cli.ts"; then
+# Accept either direct import or middleware import pattern
+if grep -q "import { doctor }" "$PROJECT_ROOT/src/cli.ts" || \
+   grep -q "import { doctorMiddleware }" "$PROJECT_ROOT/src/cli.ts"; then
     pass "doctor module imported in CLI"
 else
     fail "doctor module should be imported in CLI"

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -63,7 +63,9 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 3: CLI imports history module"
 
-if grep -q "import { history }" "$PROJECT_ROOT/src/cli.ts"; then
+# Accept either direct import or middleware import pattern
+if grep -q "import { history }" "$PROJECT_ROOT/src/cli.ts" || \
+   grep -q "import { historyMiddleware }" "$PROJECT_ROOT/src/cli.ts"; then
     pass "history module imported in CLI"
 else
     fail "history module should be imported in CLI"

--- a/tests/test-insights.sh
+++ b/tests/test-insights.sh
@@ -63,7 +63,9 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 3: CLI imports insights module"
 
-if grep -q "import { insights }" "$PROJECT_ROOT/src/cli.ts"; then
+# Accept either direct import or middleware import pattern
+if grep -q "import { insights }" "$PROJECT_ROOT/src/cli.ts" || \
+   grep -q "import { insightsMiddleware }" "$PROJECT_ROOT/src/cli.ts"; then
     pass "insights module imported in CLI"
 else
     fail "insights module should be imported in CLI"

--- a/tests/test-queue.sh
+++ b/tests/test-queue.sh
@@ -63,7 +63,9 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 3: CLI imports queue module"
 
-if grep -q "import { queue, queueSkip, queuePromote }" "$PROJECT_ROOT/src/cli.ts"; then
+# Accept either direct import or middleware import pattern
+if grep -q "import { queue, queueSkip, queuePromote }" "$PROJECT_ROOT/src/cli.ts" || \
+   grep -q "import { queueMiddleware }" "$PROJECT_ROOT/src/cli.ts"; then
     pass "queue module imported in CLI"
 else
     fail "queue module should be imported in CLI"


### PR DESCRIPTION
## Summary
- Migrated doctor, validate, history, and insights commands to middleware pattern
- Each command now uses `withCommand()` composition for consistent cross-cutting concerns (timing, error handling, config loading, JSON output)
- Updated CLI imports to use middleware versions
- Updated integration tests to accept both direct and middleware import patterns

## Test Plan
- [x] All 32 test suites pass (0 failures)
- [x] TypeScript compilation succeeds with no errors
- [x] Integration tests updated to accept middleware imports
- [x] Commands return proper `CommandResult` format
- [x] JSON output mode works correctly

Closes #112

```
░█████╗░██╗░░██╗░█████╗░██████╗░
██╔══██╗██║░░██║██╔══██╗██╔══██╗
██║░░╚═╝███████║███████║██║░░██║
██║░░██╗██╔══██║██╔══██║██║░░██║
╚█████╔╝██║░░██║██║░░██║██████╔╝
░╚════╝░╚═╝░░╚═╝╚═╝░░╚═╝╚═════╝░

  DOES WHAT CHAD WANTS
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors CLI to use middleware-based implementations for key commands with consistent cross-cutting behavior and JSON output support.
> 
> - Adds `validate-middleware.ts`, `history-middleware.ts`, `insights-middleware.ts`, `doctor-middleware.ts`; each composed with `withCommand(...)` (timing, error handling, directory resolution, JSON)
> - CLI now wires `validate`, `history`, `insights`, `doctor` to their middleware; `queue list` uses `queueMiddleware` (skip/promote remain legacy)
> - `validate` gains `--json` and returns success flag for exit code handling
> - Rich implementations: doctor health checks/reporting and recommendations; history filtering/formatting; insights analysis/export; all support `--json`
> - Integration tests updated to accept either direct or middleware imports for affected commands
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3114ad73e3845d1d4cd2f984fc36f6b60c703d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->