### PR TITLE
[CHAD] Add unified JSON response wrapper for consistent machine-readable output

### DIFF
--- a/docs/json-output-schema.md
+++ b/docs/json-output-schema.md
@@ -1,0 +1,281 @@
+# Unified JSON Response Schema
+
+This document describes the unified JSON response format for ChadGI commands, designed for consistent machine-readable output.
+
+## Overview
+
+ChadGI commands that support JSON output (`--json` flag) can optionally use a unified response wrapper format. This format provides:
+
+- Consistent structure across all commands
+- Error information with machine-readable codes
+- Pagination metadata for list responses
+- Runtime metrics for debugging
+
+## Enabling Unified Format
+
+The unified format is **opt-in** for backwards compatibility. Enable it using:
+
+```bash
+# Option 1: Environment variable
+export CHADGI_JSON_UNIFIED=1
+chadgi queue --json
+
+# Option 2: Command-line flag (where supported)
+chadgi status --json --json-unified
+```
+
+## Response Structure
+
+### Success Response
+
+```json
+{
+  "success": true,
+  "data": {
+    // Command-specific response data
+  },
+  "meta": {
+    "timestamp": "2026-01-15T10:30:00.000Z",
+    "version": "1.0.5",
+    "command": "queue",
+    "runtime_ms": 123
+  },
+  "pagination": {
+    "total": 100,
+    "filtered": 50,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+### Error Response
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "CONFIG_NOT_FOUND",
+    "message": "Configuration file not found at .chadgi/chadgi-config.yaml",
+    "details": {
+      // Optional additional context
+    }
+  },
+  "meta": {
+    "timestamp": "2026-01-15T10:30:00.000Z",
+    "version": "1.0.5",
+    "command": "validate",
+    "runtime_ms": 45
+  }
+}
+```
+
+## Field Definitions
+
+### Root Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `success` | boolean | Yes | Whether the operation succeeded |
+| `data` | object | On success | The response payload |
+| `error` | object | On failure | Error information |
+| `meta` | object | Yes | Execution metadata |
+| `pagination` | object | For lists | Pagination information |
+
+### Meta Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | ISO 8601 timestamp when response was generated |
+| `version` | string | ChadGI version (e.g., "1.0.5") |
+| `command` | string | Command name (e.g., "queue", "history", "status") |
+| `runtime_ms` | number | Execution time in milliseconds |
+
+### Error Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | string | Machine-readable error code |
+| `message` | string | Human-readable error message |
+| `details` | object | Optional additional error context |
+
+### Pagination Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total` | number | Total items before filtering |
+| `filtered` | number | Items after filtering (before limit/offset) |
+| `limit` | number | Maximum items returned |
+| `offset` | number | Items skipped |
+
+## Error Codes
+
+Standard error codes used across commands:
+
+### Configuration Errors
+- `CONFIG_NOT_FOUND` - Configuration file not found
+- `CONFIG_INVALID` - Configuration file has invalid format
+- `NOT_INITIALIZED` - ChadGI directory not initialized
+
+### GitHub Errors
+- `GITHUB_AUTH_ERROR` - GitHub CLI not authenticated
+- `GITHUB_API_ERROR` - GitHub API returned an error
+- `PROJECT_NOT_FOUND` - GitHub Project not found
+- `ISSUE_NOT_FOUND` - GitHub Issue not found
+
+### Validation Errors
+- `VALIDATION_ERROR` - General validation failure
+- `INVALID_ARGUMENT` - Invalid command argument
+
+### Runtime Errors
+- `COMMAND_FAILED` - Command execution failed
+- `TIMEOUT` - Operation timed out
+- `BUDGET_EXCEEDED` - Budget limit exceeded
+
+### File/Lock Errors
+- `FILE_NOT_FOUND` - Required file not found
+- `LOCK_HELD` - Task lock held by another process
+
+### Generic Errors
+- `UNKNOWN_ERROR` - Unexpected error occurred
+
+## Command-Specific Schemas
+
+### queue
+
+```json
+{
+  "success": true,
+  "data": {
+    "readyColumn": "Ready",
+    "taskCount": 3,
+    "tasks": [
+      {
+        "number": 42,
+        "title": "Add user authentication",
+        "url": "https://github.com/owner/repo/issues/42",
+        "itemId": "PVTI_xxx",
+        "category": "feature",
+        "priority": 1,
+        "priorityName": "High",
+        "labels": ["enhancement"],
+        "dependencies": [41],
+        "dependencyStatus": "resolved"
+      }
+    ]
+  },
+  "pagination": { "total": 3 }
+}
+```
+
+### history
+
+```json
+{
+  "success": true,
+  "data": {
+    "entries": [
+      {
+        "issueNumber": 42,
+        "issueTitle": "Add user authentication",
+        "outcome": "success",
+        "elapsedTime": 300,
+        "cost": 0.25,
+        "prUrl": "https://github.com/owner/repo/pull/43",
+        "startedAt": "2026-01-15T10:00:00Z",
+        "completedAt": "2026-01-15T10:05:00Z"
+      }
+    ],
+    "total": 10,
+    "filtered": 5,
+    "dateRange": {
+      "since": "2026-01-14T00:00:00Z",
+      "until": "2026-01-15T10:30:00Z"
+    },
+    "statusFilter": "success"
+  },
+  "pagination": { "total": 10, "filtered": 5, "limit": 10 }
+}
+```
+
+### status
+
+```json
+{
+  "success": true,
+  "data": {
+    "state": "running",
+    "currentTask": {
+      "id": "42",
+      "title": "Add user authentication",
+      "branch": "feature/issue-42-add-user-authentication",
+      "startedAt": "2026-01-15T10:00:00Z",
+      "elapsedSeconds": 300
+    },
+    "session": {
+      "startedAt": "2026-01-15T09:00:00Z",
+      "tasksCompleted": 3,
+      "totalCostUsd": 0.75,
+      "elapsedSeconds": 5400
+    },
+    "lastUpdated": "2026-01-15T10:05:00Z"
+  }
+}
+```
+
+## Usage Examples
+
+### CI/CD Integration
+
+```bash
+#!/bin/bash
+# Check queue and process results
+result=$(CHADGI_JSON_UNIFIED=1 chadgi queue --json)
+
+if echo "$result" | jq -e '.success' > /dev/null; then
+  task_count=$(echo "$result" | jq '.data.taskCount')
+  echo "Found $task_count tasks in queue"
+else
+  error_code=$(echo "$result" | jq -r '.error.code')
+  echo "Error: $error_code"
+  exit 1
+fi
+```
+
+### Parsing with jq
+
+```bash
+# Get task numbers from queue
+chadgi queue --json | jq '.tasks[].number'
+
+# With unified format enabled:
+CHADGI_JSON_UNIFIED=1 chadgi queue --json | jq '.data.tasks[].number'
+```
+
+### Node.js Integration
+
+```javascript
+import { execSync } from 'child_process';
+
+const result = JSON.parse(
+  execSync('CHADGI_JSON_UNIFIED=1 chadgi status --json').toString()
+);
+
+if (result.success) {
+  console.log(`State: ${result.data.state}`);
+  console.log(`Runtime: ${result.meta.runtime_ms}ms`);
+} else {
+  console.error(`Error [${result.error.code}]: ${result.error.message}`);
+}
+```
+
+## Migration from Legacy Format
+
+If you have scripts consuming the legacy JSON format, you can migrate gradually:
+
+1. **Test with unified format**: Set `CHADGI_JSON_UNIFIED=1` in a test environment
+2. **Update parsers**: Access data via `.data` instead of directly
+3. **Add error handling**: Check `.success` before accessing `.data`
+4. **Use metadata**: Leverage `runtime_ms` and `timestamp` for debugging
+
+The legacy format remains the default to avoid breaking existing integrations.

--- a/src/__tests__/utils/json-output.test.ts
+++ b/src/__tests__/utils/json-output.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Unit tests for src/utils/json-output.ts
+ *
+ * Tests the unified JSON response wrapper for consistent machine-readable output.
+ */
+
+import { jest, beforeEach, afterEach } from '@jest/globals';
+import {
+  createJsonResponse,
+  createJsonError,
+  createResponseMeta,
+  ErrorCodes,
+  isJsonResponse,
+  isJsonErrorResponse,
+  isJsonSuccessResponse,
+  wrapLegacyResponse,
+  outputJsonResponse,
+  outputJsonData,
+  type JsonResponse,
+  type ResponseMeta,
+  type ResponseError,
+  type ResponsePagination,
+} from '../../utils/json-output.js';
+
+describe('json-output', () => {
+  // Mock console.log for output functions
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // Mock Date.now for consistent timestamps in tests
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-15T10:30:00Z'));
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  describe('createResponseMeta', () => {
+    it('should create metadata with timestamp and version', () => {
+      const meta = createResponseMeta({});
+
+      expect(meta.timestamp).toBe('2026-01-15T10:30:00.000Z');
+      expect(meta.version).toBeDefined();
+      expect(typeof meta.version).toBe('string');
+    });
+
+    it('should include command when provided', () => {
+      const meta = createResponseMeta({ command: 'queue' });
+
+      expect(meta.command).toBe('queue');
+    });
+
+    it('should calculate runtime_ms when startTime is provided', () => {
+      // Set start time to 100ms ago
+      const startTime = Date.now() - 100;
+      const meta = createResponseMeta({ startTime });
+
+      expect(meta.runtime_ms).toBe(100);
+    });
+
+    it('should apply overrides', () => {
+      const meta = createResponseMeta({
+        command: 'test',
+        overrides: {
+          version: 'custom-version',
+        },
+      });
+
+      expect(meta.command).toBe('test');
+      expect(meta.version).toBe('custom-version');
+    });
+  });
+
+  describe('createJsonResponse', () => {
+    it('should create a successful response with data', () => {
+      const data = { tasks: [{ id: 1, title: 'Test' }] };
+      const response = createJsonResponse({ data });
+
+      expect(response.success).toBe(true);
+      expect(response.data).toEqual(data);
+      expect(response.error).toBeUndefined();
+      expect(response.meta).toBeDefined();
+      expect(response.meta?.timestamp).toBe('2026-01-15T10:30:00.000Z');
+    });
+
+    it('should include command in metadata', () => {
+      const response = createJsonResponse({
+        data: { value: 1 },
+        command: 'history',
+      });
+
+      expect(response.meta?.command).toBe('history');
+    });
+
+    it('should calculate runtime from startTime', () => {
+      const startTime = Date.now() - 250;
+      const response = createJsonResponse({
+        data: { value: 1 },
+        startTime,
+      });
+
+      expect(response.meta?.runtime_ms).toBe(250);
+    });
+
+    it('should include pagination when provided', () => {
+      const pagination: ResponsePagination = {
+        total: 100,
+        filtered: 50,
+        limit: 10,
+        offset: 0,
+      };
+      const response = createJsonResponse({
+        data: { items: [] },
+        pagination,
+      });
+
+      expect(response.pagination).toEqual(pagination);
+    });
+
+    it('should not include pagination when not provided', () => {
+      const response = createJsonResponse({ data: { value: 1 } });
+
+      expect(response.pagination).toBeUndefined();
+    });
+
+    it('should allow custom metadata overrides', () => {
+      const response = createJsonResponse({
+        data: { value: 1 },
+        command: 'test',
+        meta: { version: '2.0.0' },
+      });
+
+      expect(response.meta?.version).toBe('2.0.0');
+      expect(response.meta?.command).toBe('test');
+    });
+  });
+
+  describe('createJsonError', () => {
+    it('should create an error response', () => {
+      const response = createJsonError({
+        code: 'CONFIG_NOT_FOUND',
+        message: 'Configuration file not found',
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.data).toBeUndefined();
+      expect(response.error).toBeDefined();
+      expect(response.error?.code).toBe('CONFIG_NOT_FOUND');
+      expect(response.error?.message).toBe('Configuration file not found');
+      expect(response.meta).toBeDefined();
+    });
+
+    it('should include details when provided', () => {
+      const response = createJsonError({
+        code: 'VALIDATION_ERROR',
+        message: 'Multiple validation errors',
+        details: { errors: ['error1', 'error2'] },
+      });
+
+      expect(response.error?.details).toEqual({ errors: ['error1', 'error2'] });
+    });
+
+    it('should not include details when not provided', () => {
+      const response = createJsonError({
+        code: 'UNKNOWN_ERROR',
+        message: 'Something went wrong',
+      });
+
+      expect(response.error?.details).toBeUndefined();
+    });
+
+    it('should include command in metadata', () => {
+      const response = createJsonError({
+        code: 'GITHUB_AUTH_ERROR',
+        message: 'Not authenticated',
+        command: 'validate',
+      });
+
+      expect(response.meta?.command).toBe('validate');
+    });
+
+    it('should calculate runtime from startTime', () => {
+      const startTime = Date.now() - 500;
+      const response = createJsonError({
+        code: 'TIMEOUT',
+        message: 'Request timed out',
+        startTime,
+      });
+
+      expect(response.meta?.runtime_ms).toBe(500);
+    });
+  });
+
+  describe('ErrorCodes', () => {
+    it('should define standard error codes', () => {
+      expect(ErrorCodes.CONFIG_NOT_FOUND).toBe('CONFIG_NOT_FOUND');
+      expect(ErrorCodes.CONFIG_INVALID).toBe('CONFIG_INVALID');
+      expect(ErrorCodes.NOT_INITIALIZED).toBe('NOT_INITIALIZED');
+      expect(ErrorCodes.GITHUB_AUTH_ERROR).toBe('GITHUB_AUTH_ERROR');
+      expect(ErrorCodes.GITHUB_API_ERROR).toBe('GITHUB_API_ERROR');
+      expect(ErrorCodes.PROJECT_NOT_FOUND).toBe('PROJECT_NOT_FOUND');
+      expect(ErrorCodes.ISSUE_NOT_FOUND).toBe('ISSUE_NOT_FOUND');
+      expect(ErrorCodes.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+      expect(ErrorCodes.INVALID_ARGUMENT).toBe('INVALID_ARGUMENT');
+      expect(ErrorCodes.COMMAND_FAILED).toBe('COMMAND_FAILED');
+      expect(ErrorCodes.TIMEOUT).toBe('TIMEOUT');
+      expect(ErrorCodes.BUDGET_EXCEEDED).toBe('BUDGET_EXCEEDED');
+      expect(ErrorCodes.FILE_NOT_FOUND).toBe('FILE_NOT_FOUND');
+      expect(ErrorCodes.LOCK_HELD).toBe('LOCK_HELD');
+      expect(ErrorCodes.UNKNOWN_ERROR).toBe('UNKNOWN_ERROR');
+    });
+  });
+
+  describe('isJsonResponse', () => {
+    it('should return true for valid JsonResponse', () => {
+      const response: JsonResponse = { success: true, data: {} };
+      expect(isJsonResponse(response)).toBe(true);
+    });
+
+    it('should return true for error response', () => {
+      const response: JsonResponse = {
+        success: false,
+        error: { code: 'ERROR', message: 'test' },
+      };
+      expect(isJsonResponse(response)).toBe(true);
+    });
+
+    it('should return false for null', () => {
+      expect(isJsonResponse(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isJsonResponse(undefined)).toBe(false);
+    });
+
+    it('should return false for non-object', () => {
+      expect(isJsonResponse('string')).toBe(false);
+      expect(isJsonResponse(123)).toBe(false);
+    });
+
+    it('should return false for object without success property', () => {
+      expect(isJsonResponse({ data: {} })).toBe(false);
+    });
+
+    it('should return false for object with non-boolean success', () => {
+      expect(isJsonResponse({ success: 'true' })).toBe(false);
+    });
+  });
+
+  describe('isJsonErrorResponse', () => {
+    it('should return true for error response', () => {
+      const response = createJsonError({
+        code: 'ERROR',
+        message: 'test',
+      });
+      expect(isJsonErrorResponse(response)).toBe(true);
+    });
+
+    it('should return false for success response', () => {
+      const response = createJsonResponse({ data: {} });
+      expect(isJsonErrorResponse(response)).toBe(false);
+    });
+  });
+
+  describe('isJsonSuccessResponse', () => {
+    it('should return true for success response with data', () => {
+      const response = createJsonResponse({ data: { value: 1 } });
+      expect(isJsonSuccessResponse(response)).toBe(true);
+    });
+
+    it('should return false for error response', () => {
+      const response = createJsonError({
+        code: 'ERROR',
+        message: 'test',
+      });
+      expect(isJsonSuccessResponse(response)).toBe(false);
+    });
+
+    it('should return false for success response without data', () => {
+      const response: JsonResponse = { success: true };
+      expect(isJsonSuccessResponse(response)).toBe(false);
+    });
+  });
+
+  describe('wrapLegacyResponse', () => {
+    it('should wrap legacy data in unified format', () => {
+      const legacyData = { tasks: [], count: 0 };
+      const response = wrapLegacyResponse(legacyData);
+
+      expect(response.success).toBe(true);
+      expect(response.data).toEqual(legacyData);
+      expect(response.meta).toBeDefined();
+    });
+
+    it('should accept additional options', () => {
+      const legacyData = { items: [] };
+      const response = wrapLegacyResponse(legacyData, {
+        command: 'legacy-command',
+        pagination: { total: 10, limit: 5 },
+      });
+
+      expect(response.meta?.command).toBe('legacy-command');
+      expect(response.pagination).toEqual({ total: 10, limit: 5 });
+    });
+  });
+
+  describe('outputJsonResponse', () => {
+    it('should output pretty-printed JSON by default', () => {
+      const response = createJsonResponse({ data: { test: 'value' } });
+      outputJsonResponse(response);
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).toContain('\n'); // Pretty-printed has newlines
+      expect(JSON.parse(output)).toEqual(response);
+    });
+
+    it('should output compact JSON when pretty=false', () => {
+      const response = createJsonResponse({ data: { test: 'value' } });
+      outputJsonResponse(response, false);
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+      const output = consoleLogSpy.mock.calls[0][0] as string;
+      expect(output).not.toContain('\n'); // Compact has no newlines
+      expect(JSON.parse(output)).toEqual(response);
+    });
+  });
+
+  describe('outputJsonData', () => {
+    it('should wrap data and output it', () => {
+      outputJsonData({ items: [1, 2, 3] });
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+      const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+      expect(output.success).toBe(true);
+      expect(output.data).toEqual({ items: [1, 2, 3] });
+    });
+
+    it('should accept options for the response', () => {
+      outputJsonData({ value: 1 }, { command: 'test-cmd' });
+
+      const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+      expect(output.meta?.command).toBe('test-cmd');
+    });
+  });
+
+  describe('response structure consistency', () => {
+    it('should always have success field', () => {
+      const successResponse = createJsonResponse({ data: {} });
+      const errorResponse = createJsonError({ code: 'E', message: 'm' });
+
+      expect(successResponse).toHaveProperty('success');
+      expect(errorResponse).toHaveProperty('success');
+    });
+
+    it('should always have meta field', () => {
+      const successResponse = createJsonResponse({ data: {} });
+      const errorResponse = createJsonError({ code: 'E', message: 'm' });
+
+      expect(successResponse).toHaveProperty('meta');
+      expect(errorResponse).toHaveProperty('meta');
+      expect(successResponse.meta).toHaveProperty('timestamp');
+      expect(successResponse.meta).toHaveProperty('version');
+      expect(errorResponse.meta).toHaveProperty('timestamp');
+      expect(errorResponse.meta).toHaveProperty('version');
+    });
+
+    it('success response should have data, not error', () => {
+      const response = createJsonResponse({ data: { test: 1 } });
+
+      expect(response).toHaveProperty('data');
+      expect(response).not.toHaveProperty('error');
+    });
+
+    it('error response should have error, not data', () => {
+      const response = createJsonError({ code: 'E', message: 'm' });
+
+      expect(response).toHaveProperty('error');
+      expect(response).not.toHaveProperty('data');
+    });
+  });
+
+  describe('backwards compatibility and opt-in behavior', () => {
+    it('unified format is opt-in via jsonUnified option or CHADGI_JSON_UNIFIED env', () => {
+      // This documents the opt-in behavior:
+      // - Commands check options.jsonUnified || process.env.CHADGI_JSON_UNIFIED === '1'
+      // - When not enabled, commands return legacy format directly
+      // - When enabled, commands wrap response with createJsonResponse()
+
+      // Legacy format example (returned when NOT opted-in):
+      const legacyFormat = { tasks: [], count: 0 };
+
+      // Unified format (returned when opted-in):
+      const unifiedFormat = createJsonResponse({ data: legacyFormat, command: 'test' });
+
+      // Verify unified format has wrapper structure
+      expect(unifiedFormat).toHaveProperty('success', true);
+      expect(unifiedFormat).toHaveProperty('data');
+      expect(unifiedFormat).toHaveProperty('meta');
+      expect(unifiedFormat.data).toEqual(legacyFormat);
+    });
+
+    it('wrapLegacyResponse can convert existing responses', () => {
+      // Useful for migrating scripts that already consume legacy format
+      const legacyData = { state: 'running', currentTask: { id: '42' } };
+      const wrapped = wrapLegacyResponse(legacyData, { command: 'status' });
+
+      expect(wrapped.success).toBe(true);
+      expect(wrapped.data).toEqual(legacyData);
+      expect(wrapped.meta?.command).toBe('status');
+    });
+  });
+
+  describe('real-world usage scenarios', () => {
+    it('should work for queue command response', () => {
+      const response = createJsonResponse({
+        data: {
+          readyColumn: 'Ready',
+          taskCount: 3,
+          tasks: [
+            { number: 1, title: 'Task 1' },
+            { number: 2, title: 'Task 2' },
+            { number: 3, title: 'Task 3' },
+          ],
+        },
+        command: 'queue',
+        startTime: Date.now() - 150,
+        pagination: { total: 3 },
+      });
+
+      expect(response.success).toBe(true);
+      expect(response.data?.taskCount).toBe(3);
+      expect(response.meta?.command).toBe('queue');
+      expect(response.meta?.runtime_ms).toBe(150);
+      expect(response.pagination?.total).toBe(3);
+    });
+
+    it('should work for history command response', () => {
+      const response = createJsonResponse({
+        data: {
+          entries: [
+            { issueNumber: 42, outcome: 'success', elapsedTime: 300 },
+          ],
+          total: 10,
+          filtered: 1,
+        },
+        command: 'history',
+        pagination: {
+          total: 10,
+          filtered: 1,
+          limit: 1,
+        },
+      });
+
+      expect(response.success).toBe(true);
+      expect(response.data?.entries).toHaveLength(1);
+      expect(response.pagination?.total).toBe(10);
+      expect(response.pagination?.filtered).toBe(1);
+    });
+
+    it('should work for validation error response', () => {
+      const response = createJsonError({
+        code: ErrorCodes.VALIDATION_ERROR,
+        message: 'Configuration validation failed',
+        details: {
+          errors: [
+            'github.repo is required',
+            'github.project_number must be a number',
+          ],
+        },
+        command: 'validate',
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.error?.code).toBe('VALIDATION_ERROR');
+      expect(response.error?.details?.errors).toHaveLength(2);
+    });
+
+    it('should work for GitHub auth error response', () => {
+      const response = createJsonError({
+        code: ErrorCodes.GITHUB_AUTH_ERROR,
+        message: 'GitHub CLI not authenticated. Run: gh auth login',
+        command: 'validate',
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.error?.code).toBe('GITHUB_AUTH_ERROR');
+      expect(response.error?.message).toContain('gh auth login');
+    });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -344,3 +344,29 @@ export {
   keyValue,
   divider,
 } from './textui.js';
+
+// JSON Output (unified response wrapper)
+export {
+  // Types
+  type ResponseMeta,
+  type ResponseError,
+  type ResponsePagination,
+  type JsonResponse,
+  type CreateJsonResponseOptions,
+  type CreateJsonErrorOptions,
+  type ErrorCode,
+  // Factory functions
+  createResponseMeta,
+  createJsonResponse,
+  createJsonError,
+  // Error codes
+  ErrorCodes,
+  // Type guards
+  isJsonResponse,
+  isJsonErrorResponse,
+  isJsonSuccessResponse,
+  // Utilities
+  wrapLegacyResponse,
+  outputJsonResponse,
+  outputJsonData,
+} from './json-output.js';

--- a/src/utils/json-output.ts
+++ b/src/utils/json-output.ts
@@ -1,0 +1,415 @@
+/**
+ * Unified JSON response wrapper for consistent machine-readable output.
+ *
+ * This module provides a standardized response format for all CLI commands
+ * that support JSON output, making it easier for external tools and CI/CD
+ * pipelines to parse ChadGI output programmatically.
+ *
+ * @example Success response:
+ * ```json
+ * {
+ *   "success": true,
+ *   "data": { ... },
+ *   "meta": {
+ *     "timestamp": "2026-01-15T10:30:00Z",
+ *     "version": "1.0.5",
+ *     "command": "queue",
+ *     "runtime_ms": 123
+ *   }
+ * }
+ * ```
+ *
+ * @example Error response:
+ * ```json
+ * {
+ *   "success": false,
+ *   "error": {
+ *     "code": "CONFIG_NOT_FOUND",
+ *     "message": "Configuration file not found"
+ *   },
+ *   "meta": { ... }
+ * }
+ * ```
+ *
+ * @example List response with pagination:
+ * ```json
+ * {
+ *   "success": true,
+ *   "data": { "items": [...] },
+ *   "pagination": {
+ *     "total": 100,
+ *     "filtered": 50,
+ *     "limit": 10,
+ *     "offset": 0
+ *   },
+ *   "meta": { ... }
+ * }
+ * ```
+ */
+
+// Get package version for meta information
+let _packageVersion: string | null = null;
+
+/**
+ * Get the package version, caching it for subsequent calls.
+ */
+function getPackageVersion(): string {
+  if (_packageVersion !== null) {
+    return _packageVersion;
+  }
+
+  try {
+    // Try to read from package.json at runtime
+    // Using dynamic import to avoid bundling issues
+    const { readFileSync } = require('fs');
+    const { join, dirname } = require('path');
+
+    // Find package.json relative to this file
+    let searchDir = __dirname;
+    for (let i = 0; i < 5; i++) {
+      try {
+        const pkgPath = join(searchDir, 'package.json');
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name === 'chadgi') {
+          _packageVersion = pkg.version as string;
+          return _packageVersion;
+        }
+      } catch {
+        // Continue searching up
+      }
+      searchDir = dirname(searchDir);
+    }
+  } catch {
+    // Ignore errors, use fallback
+  }
+
+  _packageVersion = 'unknown';
+  return _packageVersion;
+}
+
+/**
+ * Metadata about the command execution.
+ * Useful for debugging, logging, and analytics.
+ */
+export interface ResponseMeta {
+  /** ISO timestamp when the response was generated */
+  timestamp: string;
+  /** ChadGI version */
+  version: string;
+  /** Command name that generated this response */
+  command?: string;
+  /** Execution time in milliseconds */
+  runtime_ms?: number;
+}
+
+/**
+ * Error information for failed responses.
+ */
+export interface ResponseError {
+  /** Machine-readable error code (e.g., CONFIG_NOT_FOUND, GITHUB_AUTH_ERROR) */
+  code: string;
+  /** Human-readable error message */
+  message: string;
+  /** Optional additional details */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Pagination information for list responses.
+ */
+export interface ResponsePagination {
+  /** Total number of items before filtering */
+  total: number;
+  /** Number of items after filtering (but before limit/offset) */
+  filtered?: number;
+  /** Maximum number of items returned */
+  limit?: number;
+  /** Number of items skipped */
+  offset?: number;
+}
+
+/**
+ * Unified JSON response wrapper.
+ * All commands should use this format for consistent machine-readable output.
+ *
+ * @typeParam T - The type of the data payload
+ */
+export interface JsonResponse<T = unknown> {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** The response data (present on success) */
+  data?: T;
+  /** Error information (present on failure) */
+  error?: ResponseError;
+  /** Metadata about the command execution */
+  meta?: ResponseMeta;
+  /** Pagination information for list responses */
+  pagination?: ResponsePagination;
+}
+
+/**
+ * Options for creating a JSON response.
+ */
+export interface CreateJsonResponseOptions<T = unknown> {
+  /** The response data */
+  data: T;
+  /** Command name for metadata */
+  command?: string;
+  /** Execution start time (for calculating runtime_ms) */
+  startTime?: number;
+  /** Pagination information for list responses */
+  pagination?: ResponsePagination;
+  /** Additional metadata fields */
+  meta?: Partial<ResponseMeta>;
+}
+
+/**
+ * Options for creating a JSON error response.
+ */
+export interface CreateJsonErrorOptions {
+  /** Machine-readable error code */
+  code: string;
+  /** Human-readable error message */
+  message: string;
+  /** Optional additional error details */
+  details?: Record<string, unknown>;
+  /** Command name for metadata */
+  command?: string;
+  /** Execution start time (for calculating runtime_ms) */
+  startTime?: number;
+  /** Additional metadata fields */
+  meta?: Partial<ResponseMeta>;
+}
+
+/**
+ * Create response metadata.
+ *
+ * @param options - Options for creating metadata
+ * @returns Response metadata object
+ */
+export function createResponseMeta(options: {
+  command?: string;
+  startTime?: number;
+  overrides?: Partial<ResponseMeta>;
+}): ResponseMeta {
+  const { command, startTime, overrides } = options;
+
+  const meta: ResponseMeta = {
+    timestamp: new Date().toISOString(),
+    version: getPackageVersion(),
+    ...overrides,
+  };
+
+  if (command) {
+    meta.command = command;
+  }
+
+  if (startTime !== undefined) {
+    meta.runtime_ms = Date.now() - startTime;
+  }
+
+  return meta;
+}
+
+/**
+ * Create a successful JSON response.
+ *
+ * @param options - Options for creating the response
+ * @returns A unified JSON response object
+ *
+ * @example Basic usage:
+ * ```ts
+ * const response = createJsonResponse({
+ *   data: { tasks: [...] },
+ *   command: 'queue',
+ * });
+ * ```
+ *
+ * @example With pagination:
+ * ```ts
+ * const response = createJsonResponse({
+ *   data: { entries: filteredEntries },
+ *   command: 'history',
+ *   startTime,
+ *   pagination: { total: 100, filtered: 50, limit: 10, offset: 0 },
+ * });
+ * ```
+ */
+export function createJsonResponse<T>(
+  options: CreateJsonResponseOptions<T>
+): JsonResponse<T> {
+  const { data, command, startTime, pagination, meta: metaOverrides } = options;
+
+  const response: JsonResponse<T> = {
+    success: true,
+    data,
+    meta: createResponseMeta({
+      command,
+      startTime,
+      overrides: metaOverrides,
+    }),
+  };
+
+  if (pagination) {
+    response.pagination = pagination;
+  }
+
+  return response;
+}
+
+/**
+ * Create an error JSON response.
+ *
+ * @param options - Options for creating the error response
+ * @returns A unified JSON error response object
+ *
+ * @example Basic usage:
+ * ```ts
+ * const response = createJsonError({
+ *   code: 'CONFIG_NOT_FOUND',
+ *   message: 'Configuration file not found at /path/to/config.yaml',
+ *   command: 'validate',
+ * });
+ * ```
+ *
+ * @example With details:
+ * ```ts
+ * const response = createJsonError({
+ *   code: 'VALIDATION_FAILED',
+ *   message: 'Multiple validation errors occurred',
+ *   details: { errors: ['Missing repo', 'Invalid project number'] },
+ *   command: 'validate',
+ * });
+ * ```
+ */
+export function createJsonError(options: CreateJsonErrorOptions): JsonResponse<never> {
+  const { code, message, details, command, startTime, meta: metaOverrides } = options;
+
+  const errorInfo: ResponseError = {
+    code,
+    message,
+  };
+
+  if (details) {
+    errorInfo.details = details;
+  }
+
+  return {
+    success: false,
+    error: errorInfo,
+    meta: createResponseMeta({
+      command,
+      startTime,
+      overrides: metaOverrides,
+    }),
+  };
+}
+
+/**
+ * Common error codes for ChadGI commands.
+ * Use these codes for consistent error identification across commands.
+ */
+export const ErrorCodes = {
+  // Configuration errors
+  CONFIG_NOT_FOUND: 'CONFIG_NOT_FOUND',
+  CONFIG_INVALID: 'CONFIG_INVALID',
+  NOT_INITIALIZED: 'NOT_INITIALIZED',
+
+  // GitHub errors
+  GITHUB_AUTH_ERROR: 'GITHUB_AUTH_ERROR',
+  GITHUB_API_ERROR: 'GITHUB_API_ERROR',
+  PROJECT_NOT_FOUND: 'PROJECT_NOT_FOUND',
+  ISSUE_NOT_FOUND: 'ISSUE_NOT_FOUND',
+
+  // Validation errors
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  INVALID_ARGUMENT: 'INVALID_ARGUMENT',
+
+  // Runtime errors
+  COMMAND_FAILED: 'COMMAND_FAILED',
+  TIMEOUT: 'TIMEOUT',
+  BUDGET_EXCEEDED: 'BUDGET_EXCEEDED',
+
+  // File/lock errors
+  FILE_NOT_FOUND: 'FILE_NOT_FOUND',
+  LOCK_HELD: 'LOCK_HELD',
+
+  // Generic errors
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/**
+ * Type guard to check if a value is a JsonResponse.
+ */
+export function isJsonResponse(value: unknown): value is JsonResponse {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return typeof obj.success === 'boolean';
+}
+
+/**
+ * Type guard to check if a JsonResponse represents an error.
+ */
+export function isJsonErrorResponse(response: JsonResponse): response is JsonResponse<never> {
+  return !response.success && response.error !== undefined;
+}
+
+/**
+ * Type guard to check if a JsonResponse represents success.
+ */
+export function isJsonSuccessResponse<T>(response: JsonResponse<T>): response is JsonResponse<T> & { data: T } {
+  return response.success && response.data !== undefined;
+}
+
+/**
+ * Convert a legacy response format to the unified format.
+ * Useful for migrating existing commands to the new format.
+ *
+ * @param legacyData - The legacy response data
+ * @param options - Options for the conversion
+ * @returns A unified JSON response
+ */
+export function wrapLegacyResponse<T>(
+  legacyData: T,
+  options: {
+    command?: string;
+    startTime?: number;
+    pagination?: ResponsePagination;
+  } = {}
+): JsonResponse<T> {
+  return createJsonResponse({
+    data: legacyData,
+    ...options,
+  });
+}
+
+/**
+ * Format and output a JSON response to stdout.
+ * Includes proper pretty-printing for readability.
+ *
+ * @param response - The JSON response to output
+ * @param pretty - Whether to pretty-print (default: true)
+ */
+export function outputJsonResponse<T>(response: JsonResponse<T>, pretty = true): void {
+  const output = pretty ? JSON.stringify(response, null, 2) : JSON.stringify(response);
+  console.log(output);
+}
+
+/**
+ * Create a JSON response directly from data and output it.
+ * Convenience function for simple command outputs.
+ *
+ * @param data - The data to wrap and output
+ * @param options - Options for creating the response
+ */
+export function outputJsonData<T>(
+  data: T,
+  options: Omit<CreateJsonResponseOptions<T>, 'data'> = {}
+): void {
+  const response = createJsonResponse({ ...options, data });
+  outputJsonResponse(response);
+}


### PR DESCRIPTION
## Summary
- Add `src/utils/json-output.ts` with unified JSON response types and helpers
- Create `JsonResponse<T>` interface with consistent structure: `success`, `data`, `error`, `meta`, `pagination`
- Add `createJsonResponse<T>()` helper for success responses with optional pagination
- Add `createJsonError()` helper with standard error codes (CONFIG_NOT_FOUND, GITHUB_AUTH_ERROR, etc.)
- Include runtime metrics in meta field: `timestamp`, `version`, `command`, `runtime_ms`
- Migrate 3 middleware commands to support unified format: `queue`, `history`, `status`
- Make unified format opt-in via `CHADGI_JSON_UNIFIED=1` env var or `--json-unified` flag for backwards compatibility
- Add comprehensive unit tests (38 tests covering all functions and edge cases)
- Add detailed schema documentation in `docs/json-output-schema.md`

## Test Plan
1. Run `npm test` - all 968 unit tests + 25 integration tests pass
2. Verify legacy format still works:
   ```bash
   chadgi status --json
   # Should return: { "state": "...", ... }
   ```
3. Verify unified format with env var:
   ```bash
   CHADGI_JSON_UNIFIED=1 chadgi status --json
   # Should return: { "success": true, "data": { "state": "..." }, "meta": { ... } }
   ```
4. Check documentation at `docs/json-output-schema.md`

Closes #119

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified, opt-in JSON response schema and integrates it across key commands.
> 
> - **New module**: `src/utils/json-output.ts` with `JsonResponse`, `createJsonResponse`, `createJsonError`, type guards, pagination, metadata, and standard `ErrorCodes`
> - **Middleware integration (opt-in)**: `queue`, `history`, `status` now emit unified responses when `--json` and either `--json-unified` or `CHADGI_JSON_UNIFIED=1` are set; otherwise return legacy JSON
> - **Exports**: Re-export JSON helpers via `src/utils/index.ts`
> - **Tests**: Comprehensive unit tests for response creation, type guards, formatting, and backward-compat behavior
> - **Docs**: Added `docs/json-output-schema.md` with schema, examples, and migration guidance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58d2c4fb996f577a202a075d363d2a5357da0a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->