### PR TITLE
[CHAD] Add centralized CLI option definitions to eliminate duplicate declarations

### DIFF
--- a/src/__tests__/utils/cli-options.test.ts
+++ b/src/__tests__/utils/cli-options.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Unit tests for src/utils/cli-options.ts
+ *
+ * Tests centralized CLI option definitions and helper functions.
+ */
+
+import { jest } from '@jest/globals';
+import { Command } from 'commander';
+import {
+  OPTION_DEFINITIONS,
+  STANDARD_OPTION_NAMES,
+  DEFAULT_CONFIG_PATH,
+  addStandardOption,
+  addStandardOptions,
+  getOptionDefinition,
+  isStandardOption,
+  hasOption,
+  type StandardOptionName,
+} from '../../utils/cli-options.js';
+
+describe('OPTION_DEFINITIONS', () => {
+  describe('config option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.config.flags).toBe('-c, --config <path>');
+    });
+
+    it('should include default path in description', () => {
+      expect(OPTION_DEFINITIONS.config.description).toContain(DEFAULT_CONFIG_PATH);
+    });
+
+    it('should not have a parser', () => {
+      expect(OPTION_DEFINITIONS.config.parser).toBeUndefined();
+    });
+  });
+
+  describe('json option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.json.flags).toBe('-j, --json');
+    });
+
+    it('should describe machine-readable output', () => {
+      expect(OPTION_DEFINITIONS.json.description.toLowerCase()).toContain('json');
+    });
+
+    it('should not have a parser (boolean flag)', () => {
+      expect(OPTION_DEFINITIONS.json.parser).toBeUndefined();
+    });
+  });
+
+  describe('limit option', () => {
+    it('should have correct flags with value placeholder', () => {
+      expect(OPTION_DEFINITIONS.limit.flags).toBe('-l, --limit <n>');
+    });
+
+    it('should have a numeric parser', () => {
+      expect(OPTION_DEFINITIONS.limit.parser).toBeDefined();
+      expect(typeof OPTION_DEFINITIONS.limit.parser).toBe('function');
+    });
+
+    it('should parse valid numeric values', () => {
+      const parser = OPTION_DEFINITIONS.limit.parser!;
+      expect(parser('10', undefined)).toBe(10);
+      expect(parser('100', undefined)).toBe(100);
+    });
+  });
+
+  describe('since option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.since.flags).toBe('-s, --since <time>');
+    });
+
+    it('should mention supported formats in description', () => {
+      const desc = OPTION_DEFINITIONS.since.description.toLowerCase();
+      expect(desc).toContain('7d');
+    });
+
+    it('should have a parser', () => {
+      expect(OPTION_DEFINITIONS.since.parser).toBeDefined();
+    });
+
+    it('should pass through valid time values', () => {
+      const parser = OPTION_DEFINITIONS.since.parser!;
+      expect(parser('7d', undefined)).toBe('7d');
+      expect(parser('2w', undefined)).toBe('2w');
+      expect(parser('2024-01-01', undefined)).toBe('2024-01-01');
+    });
+
+    it('should pass through invalid values for downstream handling', () => {
+      const parser = OPTION_DEFINITIONS.since.parser!;
+      // Invalid values are passed through - command handler shows warning
+      expect(parser('invalid', undefined)).toBe('invalid');
+    });
+  });
+
+  describe('verbose option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.verbose.flags).toBe('-v, --verbose');
+    });
+
+    it('should mention debugging in description', () => {
+      expect(OPTION_DEFINITIONS.verbose.description.toLowerCase()).toContain('debug');
+    });
+  });
+
+  describe('dryRun option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.dryRun.flags).toBe('-d, --dry-run');
+    });
+
+    it('should mention preview in description', () => {
+      expect(OPTION_DEFINITIONS.dryRun.description.toLowerCase()).toContain('preview');
+    });
+  });
+
+  describe('yes option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.yes.flags).toBe('-y, --yes');
+    });
+
+    it('should mention confirmation in description', () => {
+      expect(OPTION_DEFINITIONS.yes.description.toLowerCase()).toContain('confirmation');
+    });
+  });
+
+  describe('force option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.force.flags).toBe('-f, --force');
+    });
+
+    it('should mention safety in description', () => {
+      expect(OPTION_DEFINITIONS.force.description.toLowerCase()).toContain('safety');
+    });
+  });
+
+  describe('days option', () => {
+    it('should have correct flags', () => {
+      expect(OPTION_DEFINITIONS.days.flags).toBe('--days <n>');
+    });
+
+    it('should have a numeric parser', () => {
+      expect(OPTION_DEFINITIONS.days.parser).toBeDefined();
+    });
+
+    it('should parse valid day values', () => {
+      const parser = OPTION_DEFINITIONS.days.parser!;
+      expect(parser('7', undefined)).toBe(7);
+      expect(parser('30', undefined)).toBe(30);
+    });
+  });
+
+  describe('completeness', () => {
+    it('should have definitions for all standard option names', () => {
+      for (const name of STANDARD_OPTION_NAMES) {
+        expect(OPTION_DEFINITIONS[name]).toBeDefined();
+        expect(OPTION_DEFINITIONS[name].flags).toBeDefined();
+        expect(OPTION_DEFINITIONS[name].description).toBeDefined();
+      }
+    });
+  });
+});
+
+describe('STANDARD_OPTION_NAMES', () => {
+  it('should include all common options', () => {
+    expect(STANDARD_OPTION_NAMES).toContain('config');
+    expect(STANDARD_OPTION_NAMES).toContain('json');
+    expect(STANDARD_OPTION_NAMES).toContain('limit');
+    expect(STANDARD_OPTION_NAMES).toContain('since');
+    expect(STANDARD_OPTION_NAMES).toContain('verbose');
+    expect(STANDARD_OPTION_NAMES).toContain('dryRun');
+    expect(STANDARD_OPTION_NAMES).toContain('yes');
+    expect(STANDARD_OPTION_NAMES).toContain('force');
+    expect(STANDARD_OPTION_NAMES).toContain('days');
+  });
+
+  it('should be a readonly array', () => {
+    // TypeScript ensures this at compile time, but we can verify the values are stable
+    const names = [...STANDARD_OPTION_NAMES];
+    expect(names.length).toBe(9);
+  });
+});
+
+describe('DEFAULT_CONFIG_PATH', () => {
+  it('should point to .chadgi directory', () => {
+    expect(DEFAULT_CONFIG_PATH).toContain('.chadgi');
+  });
+
+  it('should be a YAML file', () => {
+    expect(DEFAULT_CONFIG_PATH).toMatch(/\.yaml$/);
+  });
+
+  it('should be the config file', () => {
+    expect(DEFAULT_CONFIG_PATH).toContain('chadgi-config');
+  });
+});
+
+describe('addStandardOption', () => {
+  it('should add a single option to a command', () => {
+    const cmd = new Command('test');
+    addStandardOption(cmd, 'config');
+
+    // Parse with the option
+    cmd.parse(['node', 'test', '--config', '/path/to/config.yaml'], { from: 'user' });
+    expect(cmd.opts().config).toBe('/path/to/config.yaml');
+  });
+
+  it('should add boolean options correctly', () => {
+    const cmd = new Command('test');
+    addStandardOption(cmd, 'json');
+
+    // Without flag
+    cmd.parse(['node', 'test'], { from: 'user' });
+    expect(cmd.opts().json).toBeUndefined();
+
+    // With flag
+    const cmd2 = new Command('test');
+    addStandardOption(cmd2, 'json');
+    cmd2.parse(['node', 'test', '--json'], { from: 'user' });
+    expect(cmd2.opts().json).toBe(true);
+  });
+
+  it('should add options with parsers', () => {
+    const cmd = new Command('test');
+    addStandardOption(cmd, 'limit');
+
+    cmd.parse(['node', 'test', '--limit', '25'], { from: 'user' });
+    expect(cmd.opts().limit).toBe(25);
+  });
+
+  it('should return the command for chaining', () => {
+    const cmd = new Command('test');
+    const result = addStandardOption(cmd, 'config');
+    expect(result).toBe(cmd);
+  });
+});
+
+describe('addStandardOptions', () => {
+  it('should add multiple options to a command', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, ['config', 'json', 'limit']);
+
+    cmd.parse(['node', 'test', '--config', '/path', '--json', '--limit', '50'], { from: 'user' });
+    const opts = cmd.opts();
+    expect(opts.config).toBe('/path');
+    expect(opts.json).toBe(true);
+    expect(opts.limit).toBe(50);
+  });
+
+  it('should work with empty array', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, []);
+
+    // Should not throw
+    cmd.parse(['node', 'test'], { from: 'user' });
+    expect(cmd.opts()).toEqual({});
+  });
+
+  it('should return the command for chaining', () => {
+    const cmd = new Command('test');
+    const result = addStandardOptions(cmd, ['config']);
+    expect(result).toBe(cmd);
+  });
+
+  it('should allow chaining with additional options', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, ['config', 'json'])
+      .option('--custom <value>', 'Custom option');
+
+    cmd.parse(['node', 'test', '--config', '/path', '--custom', 'test'], { from: 'user' });
+    const opts = cmd.opts();
+    expect(opts.config).toBe('/path');
+    expect(opts.custom).toBe('test');
+  });
+
+  it('should preserve option order', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, ['limit', 'since', 'days']);
+
+    // All options should be parseable
+    cmd.parse(['node', 'test', '--limit', '10', '--since', '7d', '--days', '30'], { from: 'user' });
+    const opts = cmd.opts();
+    expect(opts.limit).toBe(10);
+    expect(opts.since).toBe('7d');
+    expect(opts.days).toBe(30);
+  });
+});
+
+describe('getOptionDefinition', () => {
+  it('should return the definition for a standard option', () => {
+    const def = getOptionDefinition('config');
+    expect(def).toBe(OPTION_DEFINITIONS.config);
+  });
+
+  it('should return definitions for all standard options', () => {
+    for (const name of STANDARD_OPTION_NAMES) {
+      const def = getOptionDefinition(name);
+      expect(def).toBeDefined();
+      expect(def.flags).toBeDefined();
+    }
+  });
+});
+
+describe('isStandardOption', () => {
+  it('should return true for standard option names', () => {
+    expect(isStandardOption('config')).toBe(true);
+    expect(isStandardOption('json')).toBe(true);
+    expect(isStandardOption('limit')).toBe(true);
+    expect(isStandardOption('since')).toBe(true);
+    expect(isStandardOption('verbose')).toBe(true);
+    expect(isStandardOption('dryRun')).toBe(true);
+    expect(isStandardOption('yes')).toBe(true);
+    expect(isStandardOption('force')).toBe(true);
+    expect(isStandardOption('days')).toBe(true);
+  });
+
+  it('should return false for non-standard option names', () => {
+    expect(isStandardOption('custom')).toBe(false);
+    expect(isStandardOption('unknown')).toBe(false);
+    expect(isStandardOption('')).toBe(false);
+    expect(isStandardOption('CONFIG')).toBe(false); // case sensitive
+  });
+});
+
+describe('hasOption', () => {
+  it('should return true when option is defined', () => {
+    const options = { config: '/path', json: true };
+    expect(hasOption(options, 'config')).toBe(true);
+    expect(hasOption(options, 'json')).toBe(true);
+  });
+
+  it('should return false when option is undefined', () => {
+    const options = { config: undefined };
+    expect(hasOption(options, 'config')).toBe(false);
+  });
+
+  it('should return false when option is not present', () => {
+    const options = { config: '/path' };
+    expect(hasOption(options, 'json')).toBe(false);
+    expect(hasOption(options, 'limit')).toBe(false);
+  });
+
+  it('should handle empty options object', () => {
+    const options = {};
+    expect(hasOption(options, 'config')).toBe(false);
+  });
+
+  it('should handle falsy but defined values', () => {
+    const options = { json: false, limit: 0 };
+    expect(hasOption(options, 'json')).toBe(true); // false is defined
+    expect(hasOption(options, 'limit')).toBe(true); // 0 is defined
+  });
+});
+
+describe('integration with Commander', () => {
+  it('should work with subcommands', () => {
+    const program = new Command('chadgi');
+    const queueCmd = program.command('queue').description('Queue commands');
+
+    const listCmd = addStandardOptions(
+      queueCmd.command('list').description('List tasks'),
+      ['config', 'json', 'limit']
+    );
+
+    // Verify options were added to the list subcommand
+    const options = listCmd.options;
+    const optionFlags = options.map((o) => o.flags);
+    expect(optionFlags).toContain('-c, --config <path>');
+    expect(optionFlags).toContain('-j, --json');
+    expect(optionFlags).toContain('-l, --limit <n>');
+  });
+
+  it('should allow mixing standard and custom options', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, ['config', 'json'])
+      .option('--status <outcome>', 'Filter by status')
+      .option('--priority <level>', 'Filter by priority');
+
+    cmd.parse([
+      'node', 'test',
+      '--config', '/path',
+      '--json',
+      '--status', 'success',
+      '--priority', 'high',
+    ], { from: 'user' });
+
+    const opts = cmd.opts();
+    expect(opts.config).toBe('/path');
+    expect(opts.json).toBe(true);
+    expect(opts.status).toBe('success');
+    expect(opts.priority).toBe('high');
+  });
+
+  it('should support short flags', () => {
+    const cmd = new Command('test');
+    addStandardOptions(cmd, ['config', 'json', 'limit', 'verbose', 'yes', 'force']);
+
+    cmd.parse([
+      'node', 'test',
+      '-c', '/path',
+      '-j',
+      '-l', '10',
+      '-v',
+      '-y',
+      '-f',
+    ], { from: 'user' });
+
+    const opts = cmd.opts();
+    expect(opts.config).toBe('/path');
+    expect(opts.json).toBe(true);
+    expect(opts.limit).toBe(10);
+    expect(opts.verbose).toBe(true);
+    expect(opts.yes).toBe(true);
+    expect(opts.force).toBe(true);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ import {
   isVerbose,
   isTrace,
 } from './utils/debug.js';
+import { addStandardOptions } from './utils/cli-options.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -165,23 +166,22 @@ program
   .option('-j, --json', 'Output statistics as JSON')
   .action(wrapCommand(stats));
 
-program
-  .command('history')
-  .description('View task execution history')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
-  .option('-l, --limit <n>', 'Number of entries to show (default: 10)', createNumericParser('limit', 'limit'))
-  .option('-s, --since <time>', 'Show tasks since (e.g., 7d, 2w, 1m, 2024-01-01)')
+addStandardOptions(
+  program
+    .command('history')
+    .description('View task execution history'),
+  ['config', 'json', 'limit', 'since']
+)
   .option('--status <outcome>', 'Filter by outcome (success, failed, skipped)')
-  .option('-j, --json', 'Output history as JSON')
   .action(wrapCommand(historyMiddleware));
 
-program
-  .command('insights')
-  .description('Display aggregated performance analytics and profiling')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
-  .option('-j, --json', 'Output insights as JSON')
+addStandardOptions(
+  program
+    .command('insights')
+    .description('Display aggregated performance analytics and profiling'),
+  ['config', 'json', 'days']
+)
   .option('-e, --export <path>', 'Export metrics data to file')
-  .option('-d, --days <n>', 'Show only data from the last N days', createNumericParser('days', 'days'))
   .option('--category <type>', 'Filter insights by task category (e.g., bug, feature, refactor)')
   .action(wrapCommand(insightsMiddleware));
 
@@ -200,12 +200,12 @@ program
   .option('--restart', 'Start ChadGI if not currently running')
   .action(wrapCommand(resume));
 
-program
-  .command('status')
-  .description('Show current ChadGI session state')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
-  .option('-j, --json', 'Output status as JSON')
-  .action(wrapCommand(status));
+addStandardOptions(
+  program
+    .command('status')
+    .description('Show current ChadGI session state'),
+  ['config', 'json']
+).action(wrapCommand(status));
 
 program
   .command('watch')
@@ -216,27 +216,26 @@ program
   .option('-i, --interval <ms>', 'Refresh interval in milliseconds (default: 2000, min: 100)', createNumericParser('interval', 'interval'))
   .action(wrapCommand(watch));
 
-program
-  .command('doctor')
-  .description('Run comprehensive health checks and diagnostics')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
-  .option('-j, --json', 'Output health report as JSON')
+addStandardOptions(
+  program
+    .command('doctor')
+    .description('Run comprehensive health checks and diagnostics'),
+  ['config', 'json']
+)
   .option('--fix', 'Auto-remediate simple issues (clear stale locks, etc.)')
   .option('--no-mask', 'Disable secret masking in output (warning: exposes sensitive data)')
   .action(wrapCommand(doctorMiddleware));
 
-program
-  .command('cleanup')
-  .description('Clean up stale branches, old diagnostics, and rotated log files')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
+addStandardOptions(
+  program
+    .command('cleanup')
+    .description('Clean up stale branches, old diagnostics, and rotated log files'),
+  ['config', 'json', 'dryRun', 'yes', 'days']
+)
   .option('--branches', 'Delete orphaned feature branches (local and remote)')
   .option('--diagnostics', 'Remove diagnostic artifacts older than N days')
   .option('--logs', 'Remove rotated log files beyond retention limit')
   .option('--all', 'Run all cleanup operations')
-  .option('--dry-run', 'Preview what would be deleted without making changes')
-  .option('--yes', 'Skip confirmation prompts')
-  .option('--days <n>', 'Retention days for diagnostics (default: 30)', createNumericParser('days', 'days'))
-  .option('-j, --json', 'Output results as JSON')
   .action(wrapCommand(cleanup));
 
 program
@@ -288,13 +287,12 @@ const queueCommand = program
   .command('queue')
   .description('View and manage the task queue');
 
-queueCommand
-  .command('list', { isDefault: true })
-  .description('List tasks in the Ready column')
-  .option('-c, --config <path>', 'Path to config file (default: ./.chadgi/chadgi-config.yaml)')
-  .option('-j, --json', 'Output queue as JSON')
-  .option('-l, --limit <n>', 'Show only the first N tasks', createNumericParser('limit', 'limit'))
-  .action(wrapCommand(queueMiddleware));
+addStandardOptions(
+  queueCommand
+    .command('list', { isDefault: true })
+    .description('List tasks in the Ready column'),
+  ['config', 'json', 'limit']
+).action(wrapCommand(queueMiddleware));
 
 queueCommand
   .command('skip <issue-number>')

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -1,0 +1,267 @@
+/**
+ * Centralized CLI option definitions for consistent option declarations across commands.
+ *
+ * This module eliminates duplicate option declarations by providing:
+ * 1. OPTION_DEFINITIONS - Standard option configurations with flags, descriptions, and parsers
+ * 2. addStandardOptions - Helper to apply multiple standard options to a command
+ *
+ * Usage:
+ * ```ts
+ * import { addStandardOptions, OPTION_DEFINITIONS } from './utils/cli-options.js';
+ *
+ * const cmd = program.command('mycommand');
+ * addStandardOptions(cmd, ['config', 'json', 'limit']);
+ * ```
+ *
+ * @module utils/cli-options
+ */
+
+import type { Command } from 'commander';
+import { createNumericParser } from './validation.js';
+import { parseSince } from './formatting.js';
+
+/**
+ * Standard option names available for CLI commands.
+ * Use const assertion for type-safe option name references.
+ */
+export const STANDARD_OPTION_NAMES = [
+  'config',
+  'json',
+  'limit',
+  'since',
+  'verbose',
+  'dryRun',
+  'yes',
+  'force',
+  'days',
+] as const;
+
+export type StandardOptionName = (typeof STANDARD_OPTION_NAMES)[number];
+
+/**
+ * Configuration for a CLI option definition.
+ */
+export interface OptionDefinition {
+  /** Short and long flags (e.g., '-c, --config <path>') */
+  flags: string;
+  /** Description shown in help text */
+  description: string;
+  /** Default value if any */
+  defaultValue?: unknown;
+  /** Parser function for option values (e.g., numeric parsing with validation) */
+  parser?: (value: string, previous: unknown) => unknown;
+}
+
+/**
+ * Default config file path used across commands.
+ */
+export const DEFAULT_CONFIG_PATH = './.chadgi/chadgi-config.yaml';
+
+/**
+ * Centralized option definitions for common CLI options.
+ *
+ * These definitions ensure consistent naming, descriptions, and validation
+ * across all commands that use these options.
+ */
+export const OPTION_DEFINITIONS: Record<StandardOptionName, OptionDefinition> = {
+  /**
+   * Path to configuration file.
+   * Used by most commands to load ChadGI settings.
+   */
+  config: {
+    flags: '-c, --config <path>',
+    description: `Path to config file (default: ${DEFAULT_CONFIG_PATH})`,
+  },
+
+  /**
+   * JSON output mode.
+   * When enabled, command output is formatted as JSON for machine parsing.
+   */
+  json: {
+    flags: '-j, --json',
+    description: 'Output as JSON for machine-readable output',
+  },
+
+  /**
+   * Limit the number of results.
+   * Used by commands that return lists (history, queue, logs, etc.).
+   */
+  limit: {
+    flags: '-l, --limit <n>',
+    description: 'Maximum number of items to display',
+    parser: createNumericParser('limit', 'limit'),
+  },
+
+  /**
+   * Filter results by time.
+   * Supports relative formats (7d, 2w, 1m) and absolute dates (2024-01-01).
+   */
+  since: {
+    flags: '-s, --since <time>',
+    description: 'Filter by time (e.g., 7d, 2w, 1m, 2024-01-01)',
+    parser: parseSinceOption,
+  },
+
+  /**
+   * Enable verbose output for debugging.
+   * Shows additional details about command execution.
+   */
+  verbose: {
+    flags: '-v, --verbose',
+    description: 'Enable verbose output for debugging',
+  },
+
+  /**
+   * Dry run mode - preview without making changes.
+   * Shows what would happen without actually modifying anything.
+   */
+  dryRun: {
+    flags: '-d, --dry-run',
+    description: 'Preview changes without making modifications',
+  },
+
+  /**
+   * Skip confirmation prompts.
+   * Automatically answer yes to all confirmation dialogs.
+   */
+  yes: {
+    flags: '-y, --yes',
+    description: 'Skip confirmation prompts',
+  },
+
+  /**
+   * Force operation even if it would normally be blocked.
+   * Overrides safety checks and existing files.
+   */
+  force: {
+    flags: '-f, --force',
+    description: 'Force operation, overriding safety checks',
+  },
+
+  /**
+   * Number of days for time-based filtering.
+   * Used by commands that filter by age (cleanup, insights, etc.).
+   */
+  days: {
+    flags: '--days <n>',
+    description: 'Number of days for time-based filtering',
+    parser: createNumericParser('days', 'days'),
+  },
+} as const;
+
+/**
+ * Parser for the --since option that validates the time format.
+ * Returns the original string value for downstream parsing.
+ *
+ * @param value - The time value string (e.g., '7d', '2024-01-01')
+ * @returns The validated time string
+ */
+function parseSinceOption(value: string): string {
+  // Validate that the format is parseable
+  const parsed = parseSince(value);
+  if (parsed === null) {
+    // Return the value anyway - let the command handler show a more contextual warning
+    // This matches the existing behavior in history-middleware.ts
+    return value;
+  }
+  return value;
+}
+
+/**
+ * Adds a single standard option to a command.
+ *
+ * @param command - The Commander command to add the option to
+ * @param optionName - The standard option name to add
+ * @returns The command (for chaining)
+ *
+ * @example
+ * ```ts
+ * addStandardOption(program.command('status'), 'config');
+ * ```
+ */
+export function addStandardOption<T extends Command>(
+  command: T,
+  optionName: StandardOptionName
+): T {
+  const definition = OPTION_DEFINITIONS[optionName];
+
+  if (definition.parser) {
+    if (definition.defaultValue !== undefined) {
+      command.option(definition.flags, definition.description, definition.parser, definition.defaultValue);
+    } else {
+      command.option(definition.flags, definition.description, definition.parser);
+    }
+  } else if (definition.defaultValue !== undefined) {
+    command.option(definition.flags, definition.description, String(definition.defaultValue));
+  } else {
+    command.option(definition.flags, definition.description);
+  }
+
+  return command;
+}
+
+/**
+ * Adds multiple standard options to a command.
+ *
+ * This is the primary helper function for reducing duplicate option declarations.
+ * It applies each specified option with consistent flags, descriptions, and parsers.
+ *
+ * @param command - The Commander command to add options to
+ * @param optionNames - Array of standard option names to add
+ * @returns The command (for chaining)
+ *
+ * @example
+ * ```ts
+ * // Add config, json, and limit options
+ * const cmd = program.command('history');
+ * addStandardOptions(cmd, ['config', 'json', 'limit']);
+ *
+ * // Chain with additional command-specific options
+ * addStandardOptions(program.command('queue'), ['config', 'json'])
+ *   .option('--priority <level>', 'Filter by priority');
+ * ```
+ */
+export function addStandardOptions<T extends Command>(
+  command: T,
+  optionNames: StandardOptionName[]
+): T {
+  for (const optionName of optionNames) {
+    addStandardOption(command, optionName);
+  }
+  return command;
+}
+
+/**
+ * Get the option definition for a standard option.
+ * Useful when you need to inspect or customize a definition.
+ *
+ * @param optionName - The standard option name
+ * @returns The option definition
+ */
+export function getOptionDefinition(optionName: StandardOptionName): OptionDefinition {
+  return OPTION_DEFINITIONS[optionName];
+}
+
+/**
+ * Check if an option name is a valid standard option.
+ *
+ * @param name - The option name to check
+ * @returns True if the name is a valid standard option
+ */
+export function isStandardOption(name: string): name is StandardOptionName {
+  return STANDARD_OPTION_NAMES.includes(name as StandardOptionName);
+}
+
+/**
+ * Type guard for checking if options object has a standard option property.
+ *
+ * @param options - The options object to check
+ * @param optionName - The option name to check for
+ * @returns True if the options object has the specified option
+ */
+export function hasOption<T extends Record<string, unknown>>(
+  options: T,
+  optionName: StandardOptionName
+): boolean {
+  return optionName in options && options[optionName] !== undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -370,3 +370,20 @@ export {
   outputJsonResponse,
   outputJsonData,
 } from './json-output.js';
+
+// CLI Options (centralized option definitions)
+export {
+  // Constants
+  STANDARD_OPTION_NAMES,
+  OPTION_DEFINITIONS,
+  DEFAULT_CONFIG_PATH,
+  // Types
+  type StandardOptionName,
+  type OptionDefinition,
+  // Helper functions
+  addStandardOption,
+  addStandardOptions,
+  getOptionDefinition,
+  isStandardOption,
+  hasOption,
+} from './cli-options.js';

--- a/tests/test-cleanup.sh
+++ b/tests/test-cleanup.sh
@@ -118,8 +118,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 8: Cleanup command has --dry-run option"
 
+# Check either inline option definition or centralized addStandardOptions with 'dryRun'
 if grep -A15 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-dry-run"; then
     pass "--dry-run option exists for cleanup command"
+elif grep -A5 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'dryRun'"; then
+    pass "--dry-run option exists via addStandardOptions"
 else
     fail "cleanup command should have --dry-run option"
 fi
@@ -129,8 +132,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 9: Cleanup command has --yes option"
 
+# Check either inline option definition or centralized addStandardOptions with 'yes'
 if grep -A15 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-yes"; then
     pass "--yes option exists for cleanup command"
+elif grep -A5 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'yes'"; then
+    pass "--yes option exists via addStandardOptions"
 else
     fail "cleanup command should have --yes option"
 fi
@@ -140,8 +146,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 10: Cleanup command has --days option"
 
+# Check either inline option definition or centralized addStandardOptions with 'days'
 if grep -A15 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-days"; then
     pass "--days option exists for cleanup command"
+elif grep -A5 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'days'"; then
+    pass "--days option exists via addStandardOptions"
 else
     fail "cleanup command should have --days option"
 fi
@@ -151,8 +160,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 11: Cleanup command has --json option"
 
+# Check either inline option definition or centralized addStandardOptions with 'json'
 if grep -A15 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-json"; then
     pass "--json option exists for cleanup command"
+elif grep -A5 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'json'"; then
+    pass "--json option exists via addStandardOptions"
 else
     fail "cleanup command should have --json option"
 fi
@@ -162,8 +174,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 12: Cleanup command has --config option"
 
+# Check either inline option definition or centralized addStandardOptions with 'config'
 if grep -A15 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-config"; then
     pass "--config option exists for cleanup command"
+elif grep -A5 "command('cleanup')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'config'"; then
+    pass "--config option exists via addStandardOptions"
 else
     fail "cleanup command should have --config option"
 fi

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -87,8 +87,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 5: Doctor command has --json option"
 
+# Check either inline option definition or centralized addStandardOptions with 'json'
 if grep -A5 "command('doctor')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-json"; then
     pass "--json option exists for doctor command"
+elif grep -A5 "command('doctor')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'json'"; then
+    pass "--json option exists via addStandardOptions"
 else
     fail "doctor command should have --json option"
 fi
@@ -98,8 +101,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 6: Doctor command has --config option"
 
-if grep -A3 "command('doctor')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-config"; then
+# Check either inline option definition or centralized addStandardOptions with 'config'
+if grep -A5 "command('doctor')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-config"; then
     pass "--config option exists for doctor command"
+elif grep -A5 "command('doctor')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'config'"; then
+    pass "--config option exists via addStandardOptions"
 else
     fail "doctor command should have --config option"
 fi

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -76,8 +76,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 4: history command has --limit option"
 
+# Check either inline option definition or centralized addStandardOptions with 'limit'
 if grep -A10 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-limit"; then
     pass "--limit option exists for history command"
+elif grep -A5 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'limit'"; then
+    pass "--limit option exists via addStandardOptions"
 else
     fail "history command should have --limit option"
 fi
@@ -87,8 +90,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 5: history command has --since option"
 
+# Check either inline option definition or centralized addStandardOptions with 'since'
 if grep -A10 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-since"; then
     pass "--since option exists for history command"
+elif grep -A5 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'since'"; then
+    pass "--since option exists via addStandardOptions"
 else
     fail "history command should have --since option"
 fi
@@ -109,8 +115,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 7: history command has --json option"
 
+# Check either inline option definition or centralized addStandardOptions with 'json'
 if grep -A10 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-json"; then
     pass "--json option exists for history command"
+elif grep -A5 "command('history')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'json'"; then
+    pass "--json option exists via addStandardOptions"
 else
     fail "history command should have --json option"
 fi

--- a/tests/test-insights.sh
+++ b/tests/test-insights.sh
@@ -76,8 +76,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 4: insights command has --json option"
 
+# Check either inline option definition or centralized addStandardOptions with 'json'
 if grep -A10 "command('insights')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-json"; then
     pass "--json option exists for insights command"
+elif grep -A5 "command('insights')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'json'"; then
+    pass "--json option exists via addStandardOptions"
 else
     fail "insights command should have --json option"
 fi
@@ -98,8 +101,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 6: insights command has --days option"
 
+# Check either inline option definition or centralized addStandardOptions with 'days'
 if grep -A10 "command('insights')" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-days"; then
     pass "--days option exists for insights command"
+elif grep -A5 "command('insights')" "$PROJECT_ROOT/src/cli.ts" | grep -q "'days'"; then
+    pass "--days option exists via addStandardOptions"
 else
     fail "insights command should have --days option"
 fi

--- a/tests/test-queue.sh
+++ b/tests/test-queue.sh
@@ -109,8 +109,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 7: queue command has --json option"
 
+# Check either inline option definition or centralized addStandardOptions with 'json'
 if grep -A5 "command('list'" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-json"; then
     pass "--json option exists for queue list"
+elif grep -A5 "command('list'" "$PROJECT_ROOT/src/cli.ts" | grep -q "'json'"; then
+    pass "--json option exists via addStandardOptions"
 else
     fail "queue list should have --json option"
 fi
@@ -120,8 +123,11 @@ fi
 #------------------------------------------------------------------------------
 echo "Test 8: queue command has --limit option"
 
+# Check either inline option definition or centralized addStandardOptions with 'limit'
 if grep -A5 "command('list'" "$PROJECT_ROOT/src/cli.ts" | grep -q "\-\-limit"; then
     pass "--limit option exists for queue list"
+elif grep -A5 "command('list'" "$PROJECT_ROOT/src/cli.ts" | grep -q "'limit'"; then
+    pass "--limit option exists via addStandardOptions"
 else
     fail "queue list should have --limit option"
 fi


### PR DESCRIPTION
## Summary
- Created `src/utils/cli-options.ts` with `OPTION_DEFINITIONS` constant containing standard CLI options (config, json, limit, since, verbose, dryRun, yes, force, days)
- Added `addStandardOptions(command, optionNames[])` helper function for applying multiple options to commands
- Migrated 6 commands to use centralized definitions: status, history, insights, doctor, queue list, cleanup
- Added 52 comprehensive unit tests for the cli-options module
- Updated integration tests to support both inline and centralized option patterns

## Test Plan
- Run `npm test` - all integration tests pass
- Run `npm run test:unit` - all 1020 unit tests pass (including 52 new cli-options tests)
- Run `npm run build` - compiles without errors
- Verify CLI help output: `node dist/cli.js history --help` shows consistent option descriptions

Closes #120

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a centralized source of truth for common CLI options and applies it across key commands to remove duplication and ensure consistency.
> 
> - Adds `utils/cli-options.ts` with `OPTION_DEFINITIONS`, `STANDARD_OPTION_NAMES`, `DEFAULT_CONFIG_PATH`, `addStandardOption`, `addStandardOptions`, and helper/type exports (also re-exported via `utils/index.ts`)
> - Migrates `history`, `insights`, `status`, `doctor`, `queue list`, and `cleanup` to use `addStandardOptions`, preserving existing flags (e.g., `--config`, `--json`, `--limit`, `--since`, `--days`, `--dry-run`, `--yes`)
> - Adds extensive unit tests for `cli-options` and updates bash integration tests to accept both inline and centralized option patterns
> - Cleans up duplicated option declarations in `cli.ts` and imports the new helpers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ebdea7303d17d4ad2c70b6fff6d14d195707e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->