### PR TITLE
[CHAD] Add structured error logging for JSON parse failures with context

### DIFF
--- a/src/resume.ts
+++ b/src/resume.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { colors } from './utils/colors.js';
 import { ensureChadgiDirExists } from './utils/config.js';
+import { safeParseJson } from './utils/fileOps.js';
 
 // Import shared types
 import type { BaseCommandOptions, ProgressData, PauseLockData } from './types/index.js';
@@ -30,10 +31,12 @@ export async function resume(options: ResumeOptions = {}): Promise<void> {
     // Check if ChadGI is running or stopped
     let progress: ProgressData | null = null;
     if (existsSync(progressFile)) {
-      try {
-        progress = JSON.parse(readFileSync(progressFile, 'utf-8'));
-      } catch {
-        // Ignore parse errors
+      const content = readFileSync(progressFile, 'utf-8');
+      const result = safeParseJson<ProgressData>(content, {
+        filePath: progressFile,
+      });
+      if (result.success) {
+        progress = result.data;
       }
     }
 
@@ -69,10 +72,12 @@ export async function resume(options: ResumeOptions = {}): Promise<void> {
 
   // Read pause lock info before removing
   let pauseInfo: PauseLockData | null = null;
-  try {
-    pauseInfo = JSON.parse(readFileSync(pauseLockFile, 'utf-8'));
-  } catch {
-    // Ignore parse errors
+  const pauseContent = readFileSync(pauseLockFile, 'utf-8');
+  const pauseResult = safeParseJson<PauseLockData>(pauseContent, {
+    filePath: pauseLockFile,
+  });
+  if (pauseResult.success) {
+    pauseInfo = pauseResult.data;
   }
 
   // Remove the pause lock file
@@ -102,10 +107,12 @@ export async function resume(options: ResumeOptions = {}): Promise<void> {
   // Check current progress state
   let progress: ProgressData | null = null;
   if (existsSync(progressFile)) {
-    try {
-      progress = JSON.parse(readFileSync(progressFile, 'utf-8'));
-    } catch {
-      // Ignore parse errors
+    const progressContent = readFileSync(progressFile, 'utf-8');
+    const progressResult = safeParseJson<ProgressData>(progressContent, {
+      filePath: progressFile,
+    });
+    if (progressResult.success) {
+      progress = progressResult.data;
     }
   }
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -24,6 +24,7 @@ import {
   isLockStale,
   DEFAULT_LOCK_TIMEOUT_MINUTES,
 } from './locks.js';
+import { safeParseJson } from './fileOps.js';
 
 // ============================================================================
 // Session Stats
@@ -41,12 +42,11 @@ export function loadSessionStats(chadgiDir: string): SessionStats[] {
     return [];
   }
 
-  try {
-    const content = readFileSync(statsFile, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return [];
-  }
+  const content = readFileSync(statsFile, 'utf-8');
+  const result = safeParseJson<SessionStats[]>(content, {
+    filePath: statsFile,
+  });
+  return result.success ? result.data : [];
 }
 
 /**
@@ -78,13 +78,11 @@ export function loadTaskMetrics(chadgiDir: string): TaskMetrics[] {
     return [];
   }
 
-  try {
-    const content = readFileSync(metricsFile, 'utf-8');
-    const data: MetricsData = JSON.parse(content);
-    return data.tasks || [];
-  } catch {
-    return [];
-  }
+  const content = readFileSync(metricsFile, 'utf-8');
+  const result = safeParseJson<MetricsData>(content, {
+    filePath: metricsFile,
+  });
+  return result.success ? (result.data.tasks || []) : [];
 }
 
 /**
@@ -99,12 +97,11 @@ export function loadMetricsData(chadgiDir: string): MetricsData | null {
     return null;
   }
 
-  try {
-    const content = readFileSync(metricsFile, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return null;
-  }
+  const content = readFileSync(metricsFile, 'utf-8');
+  const result = safeParseJson<MetricsData>(content, {
+    filePath: metricsFile,
+  });
+  return result.success ? result.data : null;
 }
 
 /**
@@ -143,12 +140,11 @@ export function loadProgressData(chadgiDir: string): ProgressData | null {
     return null;
   }
 
-  try {
-    const content = readFileSync(progressFile, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return null;
-  }
+  const content = readFileSync(progressFile, 'utf-8');
+  const result = safeParseJson<ProgressData>(content, {
+    filePath: progressFile,
+  });
+  return result.success ? result.data : null;
 }
 
 // ============================================================================
@@ -167,12 +163,11 @@ export function loadPauseLock(chadgiDir: string): PauseLockData | null {
     return null;
   }
 
-  try {
-    const content = readFileSync(pauseLockFile, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return null;
-  }
+  const content = readFileSync(pauseLockFile, 'utf-8');
+  const result = safeParseJson<PauseLockData>(content, {
+    filePath: pauseLockFile,
+  });
+  return result.success ? result.data : null;
 }
 
 /**
@@ -198,15 +193,13 @@ export function findPendingApproval(chadgiDir: string): ApprovalLockData | null 
       (f) => f.startsWith('approval-') && f.endsWith('.lock')
     );
     for (const file of files) {
-      try {
-        const data = JSON.parse(
-          readFileSync(join(chadgiDir, file), 'utf-8')
-        ) as ApprovalLockData;
-        if (data.status === 'pending') {
-          return data;
-        }
-      } catch {
-        // Skip invalid files
+      const filePath = join(chadgiDir, file);
+      const content = readFileSync(filePath, 'utf-8');
+      const result = safeParseJson<ApprovalLockData>(content, {
+        filePath,
+      });
+      if (result.success && result.data.status === 'pending') {
+        return result.data;
       }
     }
   } catch {
@@ -228,13 +221,13 @@ export function listApprovalLocks(chadgiDir: string): ApprovalLockData[] {
       (f) => f.startsWith('approval-') && f.endsWith('.lock')
     );
     for (const file of files) {
-      try {
-        const data = JSON.parse(
-          readFileSync(join(chadgiDir, file), 'utf-8')
-        ) as ApprovalLockData;
-        approvals.push(data);
-      } catch {
-        // Skip invalid files
+      const filePath = join(chadgiDir, file);
+      const content = readFileSync(filePath, 'utf-8');
+      const result = safeParseJson<ApprovalLockData>(content, {
+        filePath,
+      });
+      if (result.success) {
+        approvals.push(result.data);
       }
     }
   } catch {
@@ -315,12 +308,11 @@ export function loadJsonFile<T>(filePath: string): T | null {
     return null;
   }
 
-  try {
-    const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return null;
-  }
+  const content = readFileSync(filePath, 'utf-8');
+  const result = safeParseJson<T>(content, {
+    filePath,
+  });
+  return result.success ? result.data : null;
 }
 
 /**

--- a/src/utils/fileOps.ts
+++ b/src/utils/fileOps.ts
@@ -4,10 +4,14 @@
  * Provides crash-safe file writing operations using the write-to-temp-then-rename
  * pattern. This ensures that files are never left in a corrupted or partial state
  * even if the process is killed during a write operation.
+ *
+ * Also provides safe JSON parsing utilities with structured error logging for
+ * debugging corrupted or malformed JSON files.
  */
 
 import { writeFileSync, renameSync, unlinkSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
+import { isVerbose } from './debug.js';
 
 /**
  * Default number of retry attempts for transient failures
@@ -201,4 +205,195 @@ export async function safeWriteJson(
 ): Promise<void> {
   const content = JSON.stringify(data, null, 2);
   await safeWriteFile(filePath, content, options);
+}
+
+// ============================================================================
+// Safe JSON Parsing
+// ============================================================================
+
+/**
+ * Maximum length for content preview in error messages (protects against exposing secrets)
+ */
+const CONTENT_PREVIEW_LENGTH = 100;
+
+/**
+ * Result of a successful JSON parse operation
+ */
+export interface SafeParseSuccess<T> {
+  success: true;
+  data: T;
+}
+
+/**
+ * Result of a failed JSON parse operation
+ */
+export interface SafeParseFailure {
+  success: false;
+  error: string;
+}
+
+/**
+ * Result type for safeParseJson - either success with data or failure with error
+ */
+export type SafeParseResult<T> = SafeParseSuccess<T> | SafeParseFailure;
+
+/**
+ * Options for safeParseJson
+ */
+export interface SafeParseJsonOptions<T> {
+  /** File path for error context (included in error messages) */
+  filePath?: string;
+  /** Optional fallback value to return on parse error (logs error but returns fallback) */
+  fallback?: T;
+}
+
+/**
+ * Extract position information from JSON parse error message
+ *
+ * @param errorMessage - The error message from JSON.parse
+ * @returns Object with line, column, and position if found
+ */
+function extractJsonErrorPosition(errorMessage: string): { position?: number; line?: number; column?: number } {
+  // Try to extract position from error like "Unexpected token at position 142"
+  const positionMatch = errorMessage.match(/position\s+(\d+)/i);
+  if (positionMatch) {
+    return { position: parseInt(positionMatch[1], 10) };
+  }
+
+  // Try to extract line/column from error like "at line 5 column 12"
+  const lineColMatch = errorMessage.match(/line\s+(\d+)\s+column\s+(\d+)/i);
+  if (lineColMatch) {
+    return {
+      line: parseInt(lineColMatch[1], 10),
+      column: parseInt(lineColMatch[2], 10),
+    };
+  }
+
+  return {};
+}
+
+/**
+ * Create a safe content preview that won't expose sensitive data
+ *
+ * @param content - The raw content string
+ * @returns A truncated preview safe for logging
+ */
+function createContentPreview(content: string): string {
+  if (!content || content.length === 0) {
+    return '<empty>';
+  }
+
+  // Check for binary content (non-printable characters)
+  const printableRatio = content.substring(0, Math.min(200, content.length))
+    .split('')
+    .filter(c => {
+      const code = c.charCodeAt(0);
+      // Allow printable ASCII and common whitespace
+      return (code >= 32 && code <= 126) || code === 9 || code === 10 || code === 13;
+    }).length / Math.min(200, content.length);
+
+  if (printableRatio < 0.8) {
+    return '<binary content>';
+  }
+
+  // Truncate and indicate if truncated
+  const preview = content.substring(0, CONTENT_PREVIEW_LENGTH);
+  const truncated = content.length > CONTENT_PREVIEW_LENGTH;
+
+  // Replace newlines for cleaner single-line output
+  const cleaned = preview.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+
+  return truncated ? `${cleaned}...` : cleaned;
+}
+
+/**
+ * Log a JSON parse error to stderr with context
+ *
+ * @param error - The parse error
+ * @param content - The content that failed to parse
+ * @param options - Options containing file path and other context
+ */
+function logJsonParseError(
+  error: Error,
+  content: string,
+  options: SafeParseJsonOptions<unknown>
+): void {
+  const { filePath } = options;
+  const verbose = isVerbose();
+
+  // Build error message components
+  const errorMsg = error.message;
+  const positionInfo = extractJsonErrorPosition(errorMsg);
+  const preview = createContentPreview(content);
+
+  // Basic error message to stderr
+  const fileContext = filePath ? ` in ${filePath}` : '';
+  process.stderr.write(`[WARN] JSON parse error${fileContext}: ${errorMsg}\n`);
+
+  // Additional details in verbose/debug mode
+  if (verbose) {
+    if (positionInfo.position !== undefined) {
+      process.stderr.write(`[DEBUG]   Position: ${positionInfo.position}\n`);
+    }
+    if (positionInfo.line !== undefined && positionInfo.column !== undefined) {
+      process.stderr.write(`[DEBUG]   Line: ${positionInfo.line}, Column: ${positionInfo.column}\n`);
+    }
+    process.stderr.write(`[DEBUG]   Content preview: ${preview}\n`);
+    process.stderr.write(`[DEBUG]   Content length: ${content.length} bytes\n`);
+  }
+}
+
+/**
+ * Safely parse JSON content with structured error logging.
+ *
+ * Unlike JSON.parse which throws on invalid input, this function:
+ * - Returns a typed result object indicating success or failure
+ * - Logs parse errors to stderr with context (file path, error position, content preview)
+ * - Shows additional details when --verbose/--debug flag is set
+ * - Protects against exposing sensitive data in error logs
+ * - Optionally returns a fallback value instead of a failure result
+ *
+ * @param content - The JSON string to parse
+ * @param options - Options for error logging and fallback behavior
+ * @returns A result object with either { success: true, data: T } or { success: false, error: string }
+ *
+ * @example
+ * ```typescript
+ * // Basic usage with result checking
+ * const result = safeParseJson<Config>(content, { filePath: '/path/to/config.json' });
+ * if (result.success) {
+ *   console.log(result.data);
+ * } else {
+ *   console.error(result.error);
+ * }
+ *
+ * // With fallback value - always returns data
+ * const result = safeParseJson<Config[]>(content, {
+ *   filePath: '/path/to/stats.json',
+ *   fallback: [],
+ * });
+ * // result.success is always true when fallback is provided
+ * // If parse fails, result.data is the fallback value
+ * ```
+ */
+export function safeParseJson<T>(
+  content: string,
+  options: SafeParseJsonOptions<T> = {}
+): SafeParseResult<T> {
+  try {
+    const data = JSON.parse(content) as T;
+    return { success: true, data };
+  } catch (error) {
+    const parseError = error instanceof Error ? error : new Error(String(error));
+
+    // Log the error with context
+    logJsonParseError(parseError, content, options);
+
+    // If fallback is provided, return success with fallback value
+    if ('fallback' in options && options.fallback !== undefined) {
+      return { success: true, data: options.fallback };
+    }
+
+    return { success: false, error: parseError.message };
+  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -161,13 +161,18 @@ export {
   type ValidationResult,
 } from './validation.js';
 
-// File Operations (atomic writes)
+// File Operations (atomic writes and safe parsing)
 export {
   atomicWriteFile,
   atomicWriteJson,
   safeWriteFile,
   safeWriteJson,
+  safeParseJson,
   type SafeWriteOptions,
+  type SafeParseSuccess,
+  type SafeParseFailure,
+  type SafeParseResult,
+  type SafeParseJsonOptions,
 } from './fileOps.js';
 
 // Progress (progress bars and spinners)


### PR DESCRIPTION
## Summary
- Add `safeParseJson<T>()` utility in `src/utils/fileOps.ts` that provides structured error logging for JSON parse failures
- Returns typed result: `{ success: true, data: T } | { success: false, error: string }`
- Logs parse errors to stderr with context (file path, error message, truncated content preview)
- Shows detailed debug info (position, line/column, content preview) when `--verbose`/`--debug` is enabled
- Protects against exposing sensitive data by truncating content preview to 100 chars and detecting binary content
- Supports optional fallback value that returns success with fallback on parse error
- Replace silent catch blocks in affected files:
  - `src/utils/data.ts` (loadSessionStats, loadTaskMetrics, loadMetricsData, loadProgressData, loadPauseLock, findPendingApproval, listApprovalLocks, loadJsonFile)
  - `src/utils/locks.ts` (readTaskLock, listTaskLocks)
  - `src/pause.ts` (pause lock and progress file parsing)
  - `src/resume.ts` (progress and pause lock parsing)
- Export `safeParseJson` and related types from `utils/index.ts`
- Add 15 comprehensive unit tests for safeParseJson covering malformed JSON, empty files, binary content, verbose mode, fallback values

## Test Plan
- Run `npm run build` - should succeed
- Run `npm run test:unit` - all 1109 tests pass including 15 new safeParseJson tests
- Manually test by corrupting a JSON file (e.g., `.chadgi/chadgi-stats.json`) and running `chadgi history`:
  - Without `--verbose`: Should see `[WARN] JSON parse error in <path>: <error>`
  - With `--verbose`: Should additionally see `[DEBUG]` lines with position info and content preview

Closes #126

---
\`\`\`
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
\`\`\`
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds robust, non-throwing JSON parsing with contextual logging and integrates it across modules that read `.chadgi` JSON files.
> 
> - **New** `safeParseJson<T>` in `utils/fileOps.ts`: returns `{ success, data|error }`, logs `[WARN]` with file context; verbose mode prints position, content preview (truncated/binary-safe), and length; supports `fallback`
> - **Refactors** JSON reads to use `safeParseJson`: `pause.ts` (pause lock, progress), `resume.ts` (pause lock, progress), `utils/data.ts` (session stats, metrics, metrics data, progress, pause lock, approvals, `loadJsonFile`), `utils/locks.ts` (`readTaskLock`, `listTaskLocks`)
> - **Exports** `safeParseJson` and types via `utils/index.ts`
> - **Tests**: adds extensive unit tests for parsing behavior in `__tests__/utils/fileOps.test.ts` (including verbose mode, binary content detection, fallback handling)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c8885b40379508f2b5b0c12f4d2bde30e60eb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->