### PR TITLE
[CHAD] Add JSON schema validation and bounds checking for persisted data

### DIFF
--- a/src/__tests__/utils/data-schema.test.ts
+++ b/src/__tests__/utils/data-schema.test.ts
@@ -1,0 +1,809 @@
+/**
+ * Unit tests for src/utils/data-schema.ts
+ *
+ * Tests JSON schema validation and bounds checking for persisted data structures.
+ */
+
+import { jest } from '@jest/globals';
+
+// Track isVerbose state
+let isVerboseState = false;
+
+// Mock the debug module
+jest.unstable_mockModule('../../utils/debug.js', () => ({
+  isVerbose: jest.fn(() => isVerboseState),
+}));
+
+// Import after mocking
+const {
+  validateSchema,
+  validateArray,
+  getSchema,
+  DATA_BOUNDS,
+  SESSION_STATS_SCHEMA,
+  TASK_METRICS_SCHEMA,
+  METRICS_DATA_SCHEMA,
+  TASK_LOCK_DATA_SCHEMA,
+  PROGRESS_DATA_SCHEMA,
+  PAUSE_LOCK_DATA_SCHEMA,
+  APPROVAL_LOCK_DATA_SCHEMA,
+} = await import('../../utils/data-schema.js');
+
+describe('data-schema utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isVerboseState = false;
+  });
+
+  // Capture stderr output for verbose mode tests
+  let stderrOutput: string;
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    stderrOutput = '';
+    originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: string) => {
+      stderrOutput += chunk;
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  describe('DATA_BOUNDS', () => {
+    it('should have reasonable bounds for costs', () => {
+      expect(DATA_BOUNDS.maxCostUsd).toBe(1000);
+    });
+
+    it('should have reasonable bounds for durations', () => {
+      // 1 week in seconds
+      expect(DATA_BOUNDS.maxDurationSecs).toBe(7 * 24 * 60 * 60);
+    });
+
+    it('should have reasonable bounds for task counts', () => {
+      expect(DATA_BOUNDS.maxTasks).toBe(10000);
+      expect(DATA_BOUNDS.maxIterations).toBe(100);
+    });
+  });
+
+  describe('validateSchema', () => {
+    describe('type validation', () => {
+      it('should reject non-object data', () => {
+        const result = validateSchema('not an object', SESSION_STATS_SCHEMA);
+        expect(result.valid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0].message).toContain('Expected object');
+      });
+
+      it('should reject null data', () => {
+        const result = validateSchema(null, SESSION_STATS_SCHEMA);
+        expect(result.valid).toBe(false);
+      });
+
+      it('should reject arrays when expecting object', () => {
+        const result = validateSchema([], SESSION_STATS_SCHEMA);
+        expect(result.valid).toBe(false);
+      });
+
+      it('should validate field types', () => {
+        const data = {
+          session_id: 123, // Should be string
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path === 'session_id')).toBe(true);
+      });
+    });
+
+    describe('required field validation', () => {
+      it('should fail when required fields are missing', () => {
+        const data = {
+          session_id: 'test-session',
+          // Missing required fields
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.message.includes('Required field'))).toBe(true);
+      });
+
+      it('should allow optional fields to be missing', () => {
+        const data = {
+          issue_number: 42,
+          session_id: 'session-123',
+          pid: 1234,
+          hostname: 'test-host',
+          locked_at: '2026-01-15T10:00:00Z',
+          last_heartbeat: '2026-01-15T10:05:00Z',
+          // worker_id and repo_name are optional
+        };
+
+        const result = validateSchema(data, TASK_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('numeric bounds validation', () => {
+      it('should reject negative values when min is 0', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: -100, // Invalid: negative
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path === 'duration_secs')).toBe(true);
+      });
+
+      it('should reject values exceeding maximum', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 999999999999, // Exceeds max
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+
+      it('should reject non-integers when integer is required', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200.5, // Should be integer
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+
+      it('should allow floats for non-integer fields', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1234, // Float is OK for cost
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('string validation', () => {
+      it('should validate string length constraints', () => {
+        const data = {
+          session_id: '', // Empty string - below minLength
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path === 'session_id')).toBe(true);
+      });
+
+      it('should validate timestamp patterns', () => {
+        const data = {
+          session_id: 'test',
+          started_at: 'not-a-timestamp',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path === 'started_at')).toBe(true);
+      });
+
+      it('should validate enum values', () => {
+        const data = {
+          status: 'invalid_status', // Not in enum
+          created_at: '2026-01-15T10:00:00Z',
+          issue_number: 42,
+          phase: 'phase1',
+        };
+
+        const result = validateSchema(data, APPROVAL_LOCK_DATA_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.path === 'status')).toBe(true);
+      });
+
+      it('should accept valid enum values', () => {
+        const data = {
+          status: 'pending',
+          created_at: '2026-01-15T10:00:00Z',
+          issue_number: 42,
+          phase: 'phase1',
+        };
+
+        const result = validateSchema(data, APPROVAL_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('recovery mechanism', () => {
+      it('should recover missing fields with defaults', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          // duration_secs is missing but has default
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema<Record<string, unknown>>(data, SESSION_STATS_SCHEMA, { recover: true });
+        expect(result.valid).toBe(true);
+        expect(result.hasRecoveries).toBe(true);
+        expect(result.data?.duration_secs).toBe(0); // Default value
+      });
+
+      it('should recover out-of-bounds values with defaults', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: -100, // Invalid - will be recovered
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema<Record<string, unknown>>(data, SESSION_STATS_SCHEMA, { recover: true });
+        expect(result.valid).toBe(true);
+        expect(result.hasRecoveries).toBe(true);
+        expect(result.data?.duration_secs).toBe(0); // Recovered to default
+      });
+
+      it('should not recover fields without defaults', () => {
+        const data = {
+          session_id: 123, // Wrong type, no default for session_id
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: true });
+        // Can't recover session_id because it's required and has no default
+        expect(result.valid).toBe(false);
+      });
+
+      it('should mark errors as recovered when using defaults', () => {
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: -100, // Will be recovered
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: true });
+        const recoveredErrors = result.errors.filter(e => e.recovered);
+        expect(recoveredErrors.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('verbose mode', () => {
+      it('should log validation errors in verbose mode', () => {
+        isVerboseState = true;
+
+        const data = {
+          session_id: 123, // Wrong type
+        };
+
+        validateSchema(data, SESSION_STATS_SCHEMA, { filePath: '/test/stats.json' });
+
+        expect(stderrOutput).toContain('[DEBUG]');
+        expect(stderrOutput).toContain('Schema validation errors');
+      });
+
+      it('should log recovery info in verbose mode', () => {
+        isVerboseState = true;
+
+        const data = {
+          session_id: 'test',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: -100, // Will be recovered
+          tasks_attempted: 1,
+          tasks_completed: 1,
+          successful_tasks: [],
+          failed_tasks: [],
+          total_cost_usd: 0.1,
+          gigachad_mode: false,
+          gigachad_merges: 0,
+          repo: 'test/repo',
+        };
+
+        validateSchema(data, SESSION_STATS_SCHEMA, { recover: true });
+
+        expect(stderrOutput).toContain('Recovered');
+      });
+    });
+  });
+
+  describe('validateArray', () => {
+    it('should validate each item in array', () => {
+      const items = [
+        {
+          issue_number: 42,
+          started_at: '2026-01-15T10:00:00Z',
+          duration_secs: 300,
+          status: 'completed',
+          iterations: 1,
+          cost_usd: 0.1,
+        },
+        {
+          issue_number: 43,
+          started_at: '2026-01-15T11:00:00Z',
+          duration_secs: 600,
+          status: 'failed',
+          iterations: 2,
+          cost_usd: 0.2,
+        },
+      ];
+
+      const result = validateArray(items, TASK_METRICS_SCHEMA);
+      expect(result.valid).toBe(true);
+      expect(result.data).toHaveLength(2);
+    });
+
+    it('should filter out invalid items when recovering', () => {
+      const items = [
+        {
+          issue_number: 42,
+          started_at: '2026-01-15T10:00:00Z',
+          duration_secs: 300,
+          status: 'completed',
+          iterations: 1,
+          cost_usd: 0.1,
+        },
+        {
+          issue_number: 'not-a-number', // Invalid
+          started_at: '2026-01-15T11:00:00Z',
+          duration_secs: 600,
+          status: 'invalid', // Also invalid
+          iterations: 2,
+          cost_usd: 0.2,
+        },
+      ];
+
+      const result = validateArray<Record<string, unknown>>(items, TASK_METRICS_SCHEMA, { recover: true });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].issue_number).toBe(42);
+    });
+
+    it('should reject non-array input', () => {
+      const result = validateArray('not an array', TASK_METRICS_SCHEMA);
+      expect(result.valid).toBe(false);
+      expect(result.data).toEqual([]);
+    });
+
+    it('should return empty array for empty input', () => {
+      const result = validateArray([], TASK_METRICS_SCHEMA);
+      expect(result.valid).toBe(true);
+      expect(result.data).toEqual([]);
+    });
+
+    it('should add item index to error paths', () => {
+      const items = [
+        { issue_number: 'invalid' },
+      ];
+
+      const result = validateArray(items, TASK_METRICS_SCHEMA, { recover: false });
+      expect(result.errors.some(e => e.path.includes('[0]'))).toBe(true);
+    });
+  });
+
+  describe('getSchema', () => {
+    it('should return schema by name', () => {
+      expect(getSchema('SessionStats')).toBe(SESSION_STATS_SCHEMA);
+      expect(getSchema('TaskMetrics')).toBe(TASK_METRICS_SCHEMA);
+      expect(getSchema('TaskLockData')).toBe(TASK_LOCK_DATA_SCHEMA);
+      expect(getSchema('ProgressData')).toBe(PROGRESS_DATA_SCHEMA);
+    });
+
+    it('should return undefined for unknown schema', () => {
+      expect(getSchema('UnknownSchema')).toBeUndefined();
+    });
+  });
+
+  describe('specific schemas', () => {
+    describe('SESSION_STATS_SCHEMA', () => {
+      it('should validate a complete valid session', () => {
+        const session = {
+          session_id: 'session-001',
+          started_at: '2026-01-15T10:00:00Z',
+          ended_at: '2026-01-15T12:00:00Z',
+          duration_secs: 7200,
+          tasks_attempted: 5,
+          tasks_completed: 4,
+          successful_tasks: [{ issue: 42 }, { issue: 43 }],
+          failed_tasks: [{ issue: 44, reason: 'timeout' }],
+          total_cost_usd: 1.23,
+          gigachad_mode: true,
+          gigachad_merges: 3,
+          repo: 'owner/repo',
+        };
+
+        const result = validateSchema(session, SESSION_STATS_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('TASK_METRICS_SCHEMA', () => {
+      it('should validate task metrics with all fields', () => {
+        const metrics = {
+          issue_number: 42,
+          started_at: '2026-01-15T10:00:00Z',
+          completed_at: '2026-01-15T10:30:00Z',
+          duration_secs: 1800,
+          status: 'completed',
+          iterations: 3,
+          cost_usd: 0.45,
+          category: 'feature',
+          retry_count: 1,
+          phases: { phase1_time_secs: 900 },
+          tokens: { total_tokens: 5000 },
+        };
+
+        const result = validateSchema(metrics, TASK_METRICS_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject invalid status enum', () => {
+        const metrics = {
+          issue_number: 42,
+          started_at: '2026-01-15T10:00:00Z',
+          duration_secs: 1800,
+          status: 'pending', // Not valid for TaskMetrics
+          iterations: 1,
+          cost_usd: 0.1,
+        };
+
+        const result = validateSchema(metrics, TASK_METRICS_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe('TASK_LOCK_DATA_SCHEMA', () => {
+      it('should validate lock data with optional fields', () => {
+        const lock = {
+          issue_number: 42,
+          session_id: 'session-xyz',
+          pid: 12345,
+          hostname: 'dev-machine',
+          locked_at: '2026-01-15T10:00:00Z',
+          last_heartbeat: '2026-01-15T10:30:00Z',
+          worker_id: 2,
+          repo_name: 'my-repo',
+        };
+
+        const result = validateSchema(lock, TASK_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject lock with invalid PID', () => {
+        const lock = {
+          issue_number: 42,
+          session_id: 'session-xyz',
+          pid: 0, // Invalid - must be >= 1
+          hostname: 'dev-machine',
+          locked_at: '2026-01-15T10:00:00Z',
+          last_heartbeat: '2026-01-15T10:30:00Z',
+        };
+
+        const result = validateSchema(lock, TASK_LOCK_DATA_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe('PROGRESS_DATA_SCHEMA', () => {
+      it('should validate minimal progress data', () => {
+        const progress = {
+          status: 'idle',
+          last_updated: '2026-01-15T10:00:00Z',
+        };
+
+        const result = validateSchema(progress, PROGRESS_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should validate progress with current task', () => {
+        const progress = {
+          status: 'in_progress',
+          current_task: {
+            id: '42',
+            title: 'Add feature',
+            branch: 'feature/issue-42',
+            started_at: '2026-01-15T10:00:00Z',
+          },
+          last_updated: '2026-01-15T10:30:00Z',
+        };
+
+        const result = validateSchema(progress, PROGRESS_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should validate progress with iteration', () => {
+        const progress = {
+          status: 'in_progress',
+          iteration: {
+            current: 2,
+            max: 5,
+          },
+          last_updated: '2026-01-15T10:00:00Z',
+        };
+
+        const result = validateSchema(progress, PROGRESS_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject invalid iteration bounds', () => {
+        const progress = {
+          status: 'in_progress',
+          iteration: {
+            current: -1, // Invalid
+            max: 5,
+          },
+          last_updated: '2026-01-15T10:00:00Z',
+        };
+
+        const result = validateSchema(progress, PROGRESS_DATA_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe('PAUSE_LOCK_DATA_SCHEMA', () => {
+      it('should validate pause lock with reason', () => {
+        const pause = {
+          paused_at: '2026-01-15T10:00:00Z',
+          reason: 'User requested pause',
+          resume_at: '2026-01-15T11:00:00Z',
+        };
+
+        const result = validateSchema(pause, PAUSE_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should validate minimal pause lock', () => {
+        const pause = {
+          paused_at: '2026-01-15T10:00:00Z',
+        };
+
+        const result = validateSchema(pause, PAUSE_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('APPROVAL_LOCK_DATA_SCHEMA', () => {
+      it('should validate complete approval lock', () => {
+        const approval = {
+          status: 'pending',
+          created_at: '2026-01-15T10:00:00Z',
+          issue_number: 42,
+          issue_title: 'Add feature',
+          branch: 'feature/issue-42',
+          phase: 'phase1',
+          files_changed: 5,
+          insertions: 100,
+          deletions: 20,
+        };
+
+        const result = validateSchema(approval, APPROVAL_LOCK_DATA_SCHEMA);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject invalid phase enum', () => {
+        const approval = {
+          status: 'pending',
+          created_at: '2026-01-15T10:00:00Z',
+          issue_number: 42,
+          phase: 'invalid_phase',
+        };
+
+        const result = validateSchema(approval, APPROVAL_LOCK_DATA_SCHEMA, { recover: false });
+        expect(result.valid).toBe(false);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle null field values', () => {
+      const data = {
+        session_id: 'test',
+        started_at: null, // Invalid
+        ended_at: '2026-01-15T12:00:00Z',
+        duration_secs: 7200,
+        tasks_attempted: 1,
+        tasks_completed: 1,
+        successful_tasks: [],
+        failed_tasks: [],
+        total_cost_usd: 0.1,
+        gigachad_mode: false,
+        gigachad_merges: 0,
+        repo: 'test/repo',
+      };
+
+      const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+      expect(result.valid).toBe(false);
+    });
+
+    it('should handle undefined field values', () => {
+      const data = {
+        session_id: 'test',
+        started_at: undefined, // Missing
+        ended_at: '2026-01-15T12:00:00Z',
+        duration_secs: 7200,
+        tasks_attempted: 1,
+        tasks_completed: 1,
+        successful_tasks: [],
+        failed_tasks: [],
+        total_cost_usd: 0.1,
+        gigachad_mode: false,
+        gigachad_merges: 0,
+        repo: 'test/repo',
+      };
+
+      const result = validateSchema(data, SESSION_STATS_SCHEMA, { recover: false });
+      expect(result.valid).toBe(false);
+    });
+
+    it('should handle very large numbers within bounds', () => {
+      const data = {
+        session_id: 'test',
+        started_at: '2026-01-15T10:00:00Z',
+        ended_at: '2026-01-15T12:00:00Z',
+        duration_secs: DATA_BOUNDS.maxDurationSecs, // Max allowed
+        tasks_attempted: 1,
+        tasks_completed: 1,
+        successful_tasks: [],
+        failed_tasks: [],
+        total_cost_usd: 0.1,
+        gigachad_mode: false,
+        gigachad_merges: 0,
+        repo: 'test/repo',
+      };
+
+      const result = validateSchema(data, SESSION_STATS_SCHEMA);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should handle additional properties when allowed', () => {
+      const data = {
+        session_id: 'test',
+        started_at: '2026-01-15T10:00:00Z',
+        ended_at: '2026-01-15T12:00:00Z',
+        duration_secs: 7200,
+        tasks_attempted: 1,
+        tasks_completed: 1,
+        successful_tasks: [],
+        failed_tasks: [],
+        total_cost_usd: 0.1,
+        gigachad_mode: false,
+        gigachad_merges: 0,
+        repo: 'test/repo',
+        extra_field: 'should be allowed',
+      };
+
+      const result = validateSchema<Record<string, unknown>>(data, SESSION_STATS_SCHEMA);
+      expect(result.valid).toBe(true);
+      expect(result.data?.extra_field).toBe('should be allowed');
+    });
+
+    it('should preserve valid fields when some are invalid', () => {
+      const data = {
+        session_id: 'test',
+        started_at: '2026-01-15T10:00:00Z',
+        ended_at: '2026-01-15T12:00:00Z',
+        duration_secs: -100, // Invalid, will be recovered
+        tasks_attempted: 1,
+        tasks_completed: 1,
+        successful_tasks: [],
+        failed_tasks: [],
+        total_cost_usd: 0.1,
+        gigachad_mode: false,
+        gigachad_merges: 0,
+        repo: 'test/repo',
+      };
+
+      const result = validateSchema<Record<string, unknown>>(data, SESSION_STATS_SCHEMA, { recover: true });
+      expect(result.data?.session_id).toBe('test');
+      expect(result.data?.tasks_attempted).toBe(1);
+    });
+  });
+});

--- a/src/utils/data-schema.ts
+++ b/src/utils/data-schema.ts
@@ -1,0 +1,984 @@
+/**
+ * JSON schema validation and bounds checking for persisted data structures.
+ *
+ * Provides runtime validation for critical JSON structures that are persisted to disk,
+ * ensuring data integrity and early failure with clear messages for corrupted files.
+ *
+ * @module utils/data-schema
+ */
+
+import { isVerbose } from './debug.js';
+
+// ============================================================================
+// Schema Types
+// ============================================================================
+
+/**
+ * Supported field types for schema validation
+ */
+export type FieldType = 'string' | 'number' | 'boolean' | 'array' | 'object';
+
+/**
+ * Field constraint configuration
+ */
+export interface FieldConstraint {
+  /** Expected type for the field */
+  type: FieldType;
+  /** Whether the field is required */
+  required?: boolean;
+  /** Minimum value for numbers */
+  min?: number;
+  /** Maximum value for numbers */
+  max?: number;
+  /** Whether number must be an integer */
+  integer?: boolean;
+  /** Minimum string length */
+  minLength?: number;
+  /** Maximum string length */
+  maxLength?: number;
+  /** Regex pattern for string validation */
+  pattern?: RegExp;
+  /** Allowed string values (enum) */
+  enum?: string[];
+  /** Default value to use if field is missing (enables recovery) */
+  default?: unknown;
+  /** Nested schema for object fields */
+  properties?: Record<string, FieldConstraint>;
+  /** Schema for array items */
+  items?: FieldConstraint;
+}
+
+/**
+ * Schema definition for a data structure
+ */
+export interface DataSchema {
+  /** Human-readable name for error messages */
+  name: string;
+  /** Field constraints indexed by field name */
+  fields: Record<string, FieldConstraint>;
+  /** Allow additional properties not defined in schema */
+  additionalProperties?: boolean;
+}
+
+/**
+ * Validation error details
+ */
+export interface ValidationError {
+  /** Path to the invalid field (e.g., "session.tasks_completed") */
+  path: string;
+  /** Error message */
+  message: string;
+  /** Actual value that failed validation */
+  value?: unknown;
+  /** Whether this error was recovered from using a default value */
+  recovered?: boolean;
+}
+
+/**
+ * Result of schema validation
+ */
+export interface ValidationResult<T> {
+  /** Whether validation passed (or passed with recovery) */
+  valid: boolean;
+  /** Validated and potentially recovered data */
+  data?: T;
+  /** List of validation errors */
+  errors: ValidationError[];
+  /** Whether any fields were recovered using defaults */
+  hasRecoveries: boolean;
+}
+
+// ============================================================================
+// Schema Definitions
+// ============================================================================
+
+/**
+ * Maximum reasonable values for bounds checking
+ */
+export const DATA_BOUNDS = {
+  /** Maximum cost per task in USD (to catch obviously wrong values) */
+  maxCostUsd: 1000,
+  /** Maximum session duration in seconds (1 week) */
+  maxDurationSecs: 7 * 24 * 60 * 60,
+  /** Maximum number of tasks in a session */
+  maxTasks: 10000,
+  /** Maximum number of iterations per task */
+  maxIterations: 100,
+  /** Maximum age of a timestamp (10 years in ms) */
+  maxTimestampAge: 10 * 365 * 24 * 60 * 60 * 1000,
+  /** Minimum valid timestamp (2020-01-01) */
+  minTimestamp: new Date('2020-01-01').getTime(),
+} as const;
+
+/**
+ * Schema for SessionStats data structure
+ */
+export const SESSION_STATS_SCHEMA: DataSchema = {
+  name: 'SessionStats',
+  additionalProperties: true,
+  fields: {
+    session_id: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      maxLength: 256,
+    },
+    started_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    ended_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    duration_secs: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxDurationSecs,
+      integer: true,
+      default: 0,
+    },
+    tasks_attempted: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxTasks,
+      integer: true,
+      default: 0,
+    },
+    tasks_completed: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxTasks,
+      integer: true,
+      default: 0,
+    },
+    successful_tasks: {
+      type: 'array',
+      required: true,
+      default: [],
+    },
+    failed_tasks: {
+      type: 'array',
+      required: true,
+      default: [],
+    },
+    total_cost_usd: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxCostUsd,
+      default: 0,
+    },
+    gigachad_mode: {
+      type: 'boolean',
+      required: true,
+      default: false,
+    },
+    gigachad_merges: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxTasks,
+      integer: true,
+      default: 0,
+    },
+    repo: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      default: 'unknown/unknown',
+    },
+  },
+};
+
+/**
+ * Schema for TaskMetrics data structure
+ */
+export const TASK_METRICS_SCHEMA: DataSchema = {
+  name: 'TaskMetrics',
+  additionalProperties: true,
+  fields: {
+    issue_number: {
+      type: 'number',
+      required: true,
+      min: 1,
+      integer: true,
+    },
+    started_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    completed_at: {
+      type: 'string',
+      required: false,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    duration_secs: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxDurationSecs,
+      integer: true,
+      default: 0,
+    },
+    status: {
+      type: 'string',
+      required: true,
+      enum: ['completed', 'failed'],
+    },
+    iterations: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxIterations,
+      integer: true,
+      default: 1,
+    },
+    cost_usd: {
+      type: 'number',
+      required: true,
+      min: 0,
+      max: DATA_BOUNDS.maxCostUsd,
+      default: 0,
+    },
+    failure_reason: {
+      type: 'string',
+      required: false,
+    },
+    failure_phase: {
+      type: 'string',
+      required: false,
+    },
+    category: {
+      type: 'string',
+      required: false,
+    },
+    retry_count: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+      default: 0,
+    },
+    phases: {
+      type: 'object',
+      required: false,
+    },
+    tokens: {
+      type: 'object',
+      required: false,
+    },
+    error_recovery_time_secs: {
+      type: 'number',
+      required: false,
+      min: 0,
+      max: DATA_BOUNDS.maxDurationSecs,
+      integer: true,
+    },
+    files_modified: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+    lines_changed: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+  },
+};
+
+/**
+ * Schema for MetricsData container
+ */
+export const METRICS_DATA_SCHEMA: DataSchema = {
+  name: 'MetricsData',
+  additionalProperties: true,
+  fields: {
+    version: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      default: '1.0',
+    },
+    last_updated: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    retention_days: {
+      type: 'number',
+      required: true,
+      min: 1,
+      max: 3650,
+      integer: true,
+      default: 30,
+    },
+    tasks: {
+      type: 'array',
+      required: true,
+      default: [],
+    },
+  },
+};
+
+/**
+ * Schema for TaskLockData data structure
+ */
+export const TASK_LOCK_DATA_SCHEMA: DataSchema = {
+  name: 'TaskLockData',
+  additionalProperties: true,
+  fields: {
+    issue_number: {
+      type: 'number',
+      required: true,
+      min: 1,
+      integer: true,
+    },
+    session_id: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      maxLength: 256,
+    },
+    pid: {
+      type: 'number',
+      required: true,
+      min: 1,
+      integer: true,
+    },
+    hostname: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      maxLength: 256,
+    },
+    locked_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    last_heartbeat: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    worker_id: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+    repo_name: {
+      type: 'string',
+      required: false,
+      minLength: 1,
+    },
+  },
+};
+
+/**
+ * Schema for ProgressData data structure
+ */
+export const PROGRESS_DATA_SCHEMA: DataSchema = {
+  name: 'ProgressData',
+  additionalProperties: true,
+  fields: {
+    status: {
+      type: 'string',
+      required: true,
+      enum: ['idle', 'in_progress', 'paused', 'stopped', 'error', 'awaiting_approval'],
+    },
+    current_task: {
+      type: 'object',
+      required: false,
+      properties: {
+        id: {
+          type: 'string',
+          required: true,
+          minLength: 1,
+        },
+        title: {
+          type: 'string',
+          required: true,
+        },
+        branch: {
+          type: 'string',
+          required: true,
+        },
+        started_at: {
+          type: 'string',
+          required: true,
+          pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+        },
+      },
+    },
+    session: {
+      type: 'object',
+      required: false,
+      properties: {
+        started_at: {
+          type: 'string',
+          required: true,
+          pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+        },
+        tasks_completed: {
+          type: 'number',
+          required: true,
+          min: 0,
+          max: DATA_BOUNDS.maxTasks,
+          integer: true,
+        },
+        total_cost_usd: {
+          type: 'number',
+          required: true,
+          min: 0,
+          max: DATA_BOUNDS.maxCostUsd,
+        },
+      },
+    },
+    last_updated: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    phase: {
+      type: 'string',
+      required: false,
+    },
+    iteration: {
+      type: 'object',
+      required: false,
+      properties: {
+        current: {
+          type: 'number',
+          required: true,
+          min: 0,
+          max: DATA_BOUNDS.maxIterations,
+          integer: true,
+        },
+        max: {
+          type: 'number',
+          required: true,
+          min: 1,
+          max: DATA_BOUNDS.maxIterations,
+          integer: true,
+        },
+      },
+    },
+    recent_tools: {
+      type: 'array',
+      required: false,
+    },
+    approval_history: {
+      type: 'array',
+      required: false,
+    },
+    parallel_mode: {
+      type: 'boolean',
+      required: false,
+    },
+    parallel_workers: {
+      type: 'array',
+      required: false,
+    },
+    parallel_session: {
+      type: 'object',
+      required: false,
+    },
+  },
+};
+
+/**
+ * Schema for PauseLockData data structure
+ */
+export const PAUSE_LOCK_DATA_SCHEMA: DataSchema = {
+  name: 'PauseLockData',
+  additionalProperties: true,
+  fields: {
+    paused_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    reason: {
+      type: 'string',
+      required: false,
+    },
+    resume_at: {
+      type: 'string',
+      required: false,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+  },
+};
+
+/**
+ * Schema for ApprovalLockData data structure
+ */
+export const APPROVAL_LOCK_DATA_SCHEMA: DataSchema = {
+  name: 'ApprovalLockData',
+  additionalProperties: true,
+  fields: {
+    status: {
+      type: 'string',
+      required: true,
+      enum: ['pending', 'approved', 'rejected'],
+    },
+    created_at: {
+      type: 'string',
+      required: true,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    issue_number: {
+      type: 'number',
+      required: true,
+      min: 1,
+      integer: true,
+    },
+    issue_title: {
+      type: 'string',
+      required: false,
+    },
+    branch: {
+      type: 'string',
+      required: false,
+    },
+    phase: {
+      type: 'string',
+      required: true,
+      enum: ['pre_task', 'phase1', 'phase2'],
+    },
+    files_changed: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+    insertions: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+    deletions: {
+      type: 'number',
+      required: false,
+      min: 0,
+      integer: true,
+    },
+    approver: {
+      type: 'string',
+      required: false,
+    },
+    approved_at: {
+      type: 'string',
+      required: false,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    rejected_at: {
+      type: 'string',
+      required: false,
+      pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    },
+    comment: {
+      type: 'string',
+      required: false,
+    },
+    feedback: {
+      type: 'string',
+      required: false,
+    },
+  },
+};
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/**
+ * Get the JavaScript type of a value
+ */
+function getValueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Validate a single field against its constraint
+ */
+function validateField(
+  value: unknown,
+  constraint: FieldConstraint,
+  path: string,
+  errors: ValidationError[],
+  recover: boolean
+): { value: unknown; recovered: boolean } {
+  let recovered = false;
+
+  // Check if value is missing
+  if (value === undefined || value === null) {
+    if (constraint.required) {
+      if (recover && constraint.default !== undefined) {
+        errors.push({
+          path,
+          message: `Missing required field, using default`,
+          value: constraint.default,
+          recovered: true,
+        });
+        return { value: constraint.default, recovered: true };
+      }
+      errors.push({
+        path,
+        message: `Required field is missing`,
+        value,
+      });
+    }
+    return { value, recovered: false };
+  }
+
+  // Check type
+  const actualType = getValueType(value);
+  if (actualType !== constraint.type) {
+    if (recover && constraint.default !== undefined) {
+      errors.push({
+        path,
+        message: `Expected ${constraint.type}, got ${actualType}, using default`,
+        value: constraint.default,
+        recovered: true,
+      });
+      return { value: constraint.default, recovered: true };
+    }
+    errors.push({
+      path,
+      message: `Expected ${constraint.type}, got ${actualType}`,
+      value,
+    });
+    return { value, recovered: false };
+  }
+
+  // Type-specific validations
+  if (constraint.type === 'number') {
+    const numValue = value as number;
+
+    // Check integer constraint
+    if (constraint.integer && !Number.isInteger(numValue)) {
+      if (recover && constraint.default !== undefined) {
+        errors.push({
+          path,
+          message: `Expected integer, using default`,
+          value: constraint.default,
+          recovered: true,
+        });
+        return { value: constraint.default, recovered: true };
+      }
+      errors.push({
+        path,
+        message: `Expected integer, got float`,
+        value,
+      });
+    }
+
+    // Check bounds
+    if (constraint.min !== undefined && numValue < constraint.min) {
+      if (recover) {
+        const recoveredValue = constraint.default !== undefined ? constraint.default : constraint.min;
+        errors.push({
+          path,
+          message: `Value ${numValue} is below minimum ${constraint.min}, using ${recoveredValue}`,
+          value: recoveredValue,
+          recovered: true,
+        });
+        return { value: recoveredValue, recovered: true };
+      }
+      errors.push({
+        path,
+        message: `Value ${numValue} is below minimum ${constraint.min}`,
+        value,
+      });
+    }
+
+    if (constraint.max !== undefined && numValue > constraint.max) {
+      if (recover) {
+        const recoveredValue = constraint.default !== undefined ? constraint.default : constraint.max;
+        errors.push({
+          path,
+          message: `Value ${numValue} exceeds maximum ${constraint.max}, using ${recoveredValue}`,
+          value: recoveredValue,
+          recovered: true,
+        });
+        return { value: recoveredValue, recovered: true };
+      }
+      errors.push({
+        path,
+        message: `Value ${numValue} exceeds maximum ${constraint.max}`,
+        value,
+      });
+    }
+  }
+
+  if (constraint.type === 'string') {
+    const strValue = value as string;
+
+    // Check length constraints
+    if (constraint.minLength !== undefined && strValue.length < constraint.minLength) {
+      errors.push({
+        path,
+        message: `String length ${strValue.length} is below minimum ${constraint.minLength}`,
+        value,
+      });
+    }
+
+    if (constraint.maxLength !== undefined && strValue.length > constraint.maxLength) {
+      errors.push({
+        path,
+        message: `String length ${strValue.length} exceeds maximum ${constraint.maxLength}`,
+        value: strValue.substring(0, 50) + '...',
+      });
+    }
+
+    // Check pattern
+    if (constraint.pattern && !constraint.pattern.test(strValue)) {
+      errors.push({
+        path,
+        message: `String does not match expected pattern`,
+        value: strValue.substring(0, 50),
+      });
+    }
+
+    // Check enum
+    if (constraint.enum && !constraint.enum.includes(strValue)) {
+      if (recover && constraint.default !== undefined) {
+        errors.push({
+          path,
+          message: `Invalid enum value "${strValue}", expected one of: ${constraint.enum.join(', ')}, using default`,
+          value: constraint.default,
+          recovered: true,
+        });
+        return { value: constraint.default, recovered: true };
+      }
+      errors.push({
+        path,
+        message: `Invalid enum value "${strValue}", expected one of: ${constraint.enum.join(', ')}`,
+        value,
+      });
+    }
+  }
+
+  // Validate nested object properties
+  if (constraint.type === 'object' && constraint.properties && typeof value === 'object' && value !== null) {
+    const objValue = value as Record<string, unknown>;
+    const validatedObj: Record<string, unknown> = { ...objValue };
+
+    for (const [propName, propConstraint] of Object.entries(constraint.properties)) {
+      const propPath = path ? `${path}.${propName}` : propName;
+      const result = validateField(objValue[propName], propConstraint, propPath, errors, recover);
+      if (result.recovered) {
+        validatedObj[propName] = result.value;
+        recovered = true;
+      }
+    }
+
+    if (recovered) {
+      return { value: validatedObj, recovered: true };
+    }
+  }
+
+  // Validate array items
+  if (constraint.type === 'array' && constraint.items && Array.isArray(value)) {
+    const arrValue = value as unknown[];
+    const validatedArr: unknown[] = [];
+    let arrayRecovered = false;
+
+    for (let i = 0; i < arrValue.length; i++) {
+      const itemPath = `${path}[${i}]`;
+      const result = validateField(arrValue[i], constraint.items, itemPath, errors, recover);
+      if (result.recovered) {
+        arrayRecovered = true;
+      }
+      validatedArr.push(result.value);
+    }
+
+    if (arrayRecovered) {
+      return { value: validatedArr, recovered: true };
+    }
+  }
+
+  return { value, recovered };
+}
+
+/**
+ * Validate data against a schema with optional recovery.
+ *
+ * @param data - The data to validate
+ * @param schema - The schema to validate against
+ * @param options - Validation options
+ * @returns Validation result with errors and optional recovered data
+ */
+export function validateSchema<T>(
+  data: unknown,
+  schema: DataSchema,
+  options: {
+    /** Allow recovery using default values for invalid fields */
+    recover?: boolean;
+    /** File path for error context */
+    filePath?: string;
+  } = {}
+): ValidationResult<T> {
+  const { recover = true, filePath } = options;
+  const errors: ValidationError[] = [];
+  let hasRecoveries = false;
+
+  // Check that data is an object
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return {
+      valid: false,
+      errors: [{
+        path: '',
+        message: `Expected object for ${schema.name}, got ${getValueType(data)}`,
+        value: data,
+      }],
+      hasRecoveries: false,
+    };
+  }
+
+  const objData = data as Record<string, unknown>;
+  const validatedData: Record<string, unknown> = { ...objData };
+
+  // Validate each field defined in the schema
+  for (const [fieldName, constraint] of Object.entries(schema.fields)) {
+    const result = validateField(objData[fieldName], constraint, fieldName, errors, recover);
+    if (result.recovered) {
+      validatedData[fieldName] = result.value;
+      hasRecoveries = true;
+    }
+  }
+
+  // Log validation failures in verbose mode
+  if (errors.length > 0 && isVerbose()) {
+    const fileContext = filePath ? ` in ${filePath}` : '';
+    const nonRecoveredErrors = errors.filter(e => !e.recovered);
+    if (nonRecoveredErrors.length > 0) {
+      process.stderr.write(`[DEBUG] Schema validation errors for ${schema.name}${fileContext}:\n`);
+      for (const error of nonRecoveredErrors.slice(0, 5)) {
+        process.stderr.write(`[DEBUG]   - ${error.path}: ${error.message}\n`);
+      }
+      if (nonRecoveredErrors.length > 5) {
+        process.stderr.write(`[DEBUG]   ... and ${nonRecoveredErrors.length - 5} more errors\n`);
+      }
+    }
+    const recoveredErrors = errors.filter(e => e.recovered);
+    if (recoveredErrors.length > 0) {
+      process.stderr.write(`[DEBUG] Recovered ${recoveredErrors.length} field(s) using defaults\n`);
+    }
+  }
+
+  // Determine overall validity
+  const nonRecoveredErrors = errors.filter(e => !e.recovered);
+  const valid = nonRecoveredErrors.length === 0;
+
+  return {
+    valid,
+    data: valid || hasRecoveries ? validatedData as T : undefined,
+    errors,
+    hasRecoveries,
+  };
+}
+
+/**
+ * Validate an array of items against a schema.
+ *
+ * @param data - The array to validate
+ * @param itemSchema - The schema for each item
+ * @param options - Validation options
+ * @returns Array of validated items (invalid items are filtered out if recover is enabled)
+ */
+export function validateArray<T>(
+  data: unknown,
+  itemSchema: DataSchema,
+  options: {
+    recover?: boolean;
+    filePath?: string;
+  } = {}
+): { valid: boolean; data: T[]; errors: ValidationError[] } {
+  const { recover = true, filePath } = options;
+  const errors: ValidationError[] = [];
+
+  if (!Array.isArray(data)) {
+    return {
+      valid: false,
+      data: [],
+      errors: [{
+        path: '',
+        message: `Expected array, got ${getValueType(data)}`,
+        value: data,
+      }],
+    };
+  }
+
+  const validItems: T[] = [];
+
+  for (let i = 0; i < data.length; i++) {
+    const result = validateSchema<T>(data[i], itemSchema, {
+      recover,
+      filePath: filePath ? `${filePath}[${i}]` : `[${i}]`,
+    });
+
+    if (result.valid && result.data !== undefined) {
+      validItems.push(result.data);
+    } else if (!result.valid) {
+      // Add item index to error paths
+      for (const error of result.errors) {
+        errors.push({
+          ...error,
+          path: `[${i}].${error.path}`.replace(/\.$/, ''),
+        });
+      }
+      // If recovery is disabled, still include the item but note it's invalid
+      if (!recover) {
+        validItems.push(data[i] as T);
+      }
+    }
+  }
+
+  if (errors.length > 0 && isVerbose()) {
+    const fileContext = filePath ? ` in ${filePath}` : '';
+    const skippedCount = data.length - validItems.length;
+    if (skippedCount > 0) {
+      process.stderr.write(
+        `[DEBUG] Skipped ${skippedCount} invalid item(s) from ${itemSchema.name} array${fileContext}\n`
+      );
+    }
+  }
+
+  return {
+    valid: errors.filter(e => !e.recovered).length === 0,
+    data: validItems,
+    errors,
+  };
+}
+
+/**
+ * Get a schema by name
+ */
+export function getSchema(name: string): DataSchema | undefined {
+  const schemas: Record<string, DataSchema> = {
+    SessionStats: SESSION_STATS_SCHEMA,
+    TaskMetrics: TASK_METRICS_SCHEMA,
+    MetricsData: METRICS_DATA_SCHEMA,
+    TaskLockData: TASK_LOCK_DATA_SCHEMA,
+    ProgressData: PROGRESS_DATA_SCHEMA,
+    PauseLockData: PAUSE_LOCK_DATA_SCHEMA,
+    ApprovalLockData: APPROVAL_LOCK_DATA_SCHEMA,
+  };
+  return schemas[name];
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -168,12 +168,37 @@ export {
   safeWriteFile,
   safeWriteJson,
   safeParseJson,
+  safeParseAndValidate,
   type SafeWriteOptions,
   type SafeParseSuccess,
   type SafeParseFailure,
   type SafeParseResult,
   type SafeParseJsonOptions,
 } from './fileOps.js';
+
+// Data Schema (JSON validation and bounds checking)
+export {
+  // Types
+  type FieldType,
+  type FieldConstraint,
+  type DataSchema,
+  type ValidationError as SchemaValidationError,
+  type ValidationResult as SchemaValidationResult,
+  // Constants
+  DATA_BOUNDS,
+  // Schemas
+  SESSION_STATS_SCHEMA,
+  TASK_METRICS_SCHEMA,
+  METRICS_DATA_SCHEMA,
+  TASK_LOCK_DATA_SCHEMA,
+  PROGRESS_DATA_SCHEMA,
+  PAUSE_LOCK_DATA_SCHEMA,
+  APPROVAL_LOCK_DATA_SCHEMA,
+  // Functions
+  validateSchema,
+  validateArray,
+  getSchema,
+} from './data-schema.js';
 
 // Progress (progress bars and spinners)
 export {


### PR DESCRIPTION
## Summary
- Create `data-schema.ts` with comprehensive validation schemas for all persisted JSON structures:
  - `SessionStats` (costs, durations, task counts)
  - `TaskMetrics` (iteration counts, elapsed times)
  - `TaskLockData` (heartbeat timestamps, session IDs)
  - `ProgressData` (issue numbers, phase states)
  - `PauseLockData` and `ApprovalLockData`
- Add `DATA_BOUNDS` constants defining reasonable limits (max $1000/task, 1 week duration, 10k tasks, 100 iterations)
- Implement `validateSchema()` function with type checking, bounds validation, pattern matching, enum validation, and recovery mechanism
- Integrate validation into all data loading functions in `data.ts` and `locks.ts`
- Add 48 comprehensive unit tests covering type validation, bounds checking, recovery, and edge cases

## Test Plan
- [x] Run `npm test` - all 1157 unit tests pass
- [x] Run integration tests - all 25 tests pass
- [x] Verify schema validation catches invalid data (negative costs, excessive iterations, malformed timestamps)
- [x] Verify recovery mechanism applies defaults for recoverable fields
- [x] Verify lock data validation rejects corrupted locks (no recovery for critical data)

Closes #130

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces runtime JSON schema validation and bounds checking for all persisted data, and wires it into data/lock loaders with safe recovery and debug logging.
> 
> - Adds `utils/data-schema.ts` with `DATA_BOUNDS`, schemas for `SessionStats`, `TaskMetrics`, `MetricsData`, `TaskLockData`, `ProgressData`, `PauseLockData`, `ApprovalLockData`, plus `validateSchema`, `validateArray`, and `getSchema`
> - Integrates validation into `data.ts` loaders (`loadSessionStats`, `loadTaskMetrics`, `loadMetricsData`, `loadProgressData`, `loadPauseLock`, approval lock helpers); invalid entries filtered, recoverable fields defaulted
> - Enforces strict validation for lock files in `locks.ts` (`readTaskLock`, `listTaskLocks`) without recovery
> - Extends `fileOps.ts` with `safeParseAndValidate` and updates exports in `utils/index.ts`
> - Adds comprehensive unit tests for schemas, bounds, recovery, and verbose diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28f7b4e09b16404ac5864c50745cc3e6c3368964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->