### PR TITLE
[CHAD] Add structured diagnostic logging for silent catch handlers

### DIFF
--- a/src/__tests__/utils/diagnostics.test.ts
+++ b/src/__tests__/utils/diagnostics.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Unit tests for src/utils/diagnostics.ts
+ *
+ * Tests the structured diagnostic logging utilities for silent catch handlers.
+ */
+
+import { jest } from '@jest/globals';
+
+// Mock the colors module to avoid ANSI codes in tests
+jest.unstable_mockModule('../../utils/colors.js', () => ({
+  colors: {
+    reset: '',
+    bold: '',
+    dim: '',
+    red: '',
+    green: '',
+    yellow: '',
+    blue: '',
+    purple: '',
+    magenta: '',
+    cyan: '',
+    white: '',
+    gray: '',
+  },
+}));
+
+// Mock the debug module
+jest.unstable_mockModule('../../utils/debug.js', () => ({
+  isVerbose: jest.fn(() => false),
+}));
+
+// Import after mocking
+const { isVerbose } = await import('../../utils/debug.js');
+const {
+  ErrorCategory,
+  logSilentError,
+  getSilentErrorSummary,
+  getAllSilentErrors,
+  clearSilentErrors,
+  getSilentErrorCount,
+  hasUnknownErrors,
+  formatErrorSummary,
+} = await import('../../utils/diagnostics.js');
+
+describe('ErrorCategory enum', () => {
+  it('should have EXPECTED value', () => {
+    expect(ErrorCategory.EXPECTED).toBe('expected');
+  });
+
+  it('should have RETRIABLE value', () => {
+    expect(ErrorCategory.RETRIABLE).toBe('retriable');
+  });
+
+  it('should have TRANSIENT value', () => {
+    expect(ErrorCategory.TRANSIENT).toBe('transient');
+  });
+
+  it('should have UNKNOWN value', () => {
+    expect(ErrorCategory.UNKNOWN).toBe('unknown');
+  });
+});
+
+describe('logSilentError', () => {
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+  const mockIsVerbose = isVerbose as jest.Mock;
+
+  beforeEach(() => {
+    clearSilentErrors();
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockIsVerbose.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  describe('error registration', () => {
+    it('should register error in registry', () => {
+      logSilentError(new Error('test error'), 'test context', ErrorCategory.EXPECTED);
+
+      const summary = getSilentErrorSummary();
+      expect(summary.total).toBe(1);
+      expect(summary.byCategory[ErrorCategory.EXPECTED]).toBe(1);
+    });
+
+    it('should register multiple errors', () => {
+      logSilentError(new Error('error 1'), 'context 1', ErrorCategory.EXPECTED);
+      logSilentError(new Error('error 2'), 'context 2', ErrorCategory.UNKNOWN);
+      logSilentError(new Error('error 3'), 'context 3', ErrorCategory.TRANSIENT);
+
+      const summary = getSilentErrorSummary();
+      expect(summary.total).toBe(3);
+      expect(summary.byCategory[ErrorCategory.EXPECTED]).toBe(1);
+      expect(summary.byCategory[ErrorCategory.UNKNOWN]).toBe(1);
+      expect(summary.byCategory[ErrorCategory.TRANSIENT]).toBe(1);
+    });
+
+    it('should default to UNKNOWN category', () => {
+      logSilentError(new Error('test error'), 'test context');
+
+      const summary = getSilentErrorSummary();
+      expect(summary.byCategory[ErrorCategory.UNKNOWN]).toBe(1);
+    });
+
+    it('should capture stack trace for UNKNOWN errors', () => {
+      const error = new Error('unknown error');
+      logSilentError(error, 'unknown context', ErrorCategory.UNKNOWN);
+
+      const errors = getAllSilentErrors();
+      expect(errors[0].stack).toBeDefined();
+      expect(errors[0].stack).toContain('Error: unknown error');
+    });
+
+    it('should not capture stack trace for EXPECTED errors', () => {
+      const error = new Error('expected error');
+      logSilentError(error, 'expected context', ErrorCategory.EXPECTED);
+
+      const errors = getAllSilentErrors();
+      expect(errors[0].stack).toBeUndefined();
+    });
+  });
+
+  describe('error message extraction', () => {
+    it('should extract message from Error object', () => {
+      logSilentError(new Error('test message'), 'context', ErrorCategory.EXPECTED);
+
+      const errors = getAllSilentErrors();
+      expect(errors[0].message).toBe('test message');
+    });
+
+    it('should handle string error', () => {
+      logSilentError('string error', 'context', ErrorCategory.EXPECTED);
+
+      const errors = getAllSilentErrors();
+      expect(errors[0].message).toBe('string error');
+    });
+
+    it('should stringify object errors', () => {
+      logSilentError({ code: 'ERR', msg: 'fail' }, 'context', ErrorCategory.EXPECTED);
+
+      const errors = getAllSilentErrors();
+      expect(errors[0].message).toContain('ERR');
+      expect(errors[0].message).toContain('fail');
+    });
+
+    it('should handle null/undefined errors', () => {
+      logSilentError(null, 'context', ErrorCategory.EXPECTED);
+      logSilentError(undefined, 'context', ErrorCategory.EXPECTED);
+
+      const errors = getAllSilentErrors();
+      expect(errors.length).toBe(2);
+    });
+  });
+
+  describe('verbose output', () => {
+    it('should not output when verbose is disabled', () => {
+      mockIsVerbose.mockReturnValue(false);
+      logSilentError(new Error('test'), 'context', ErrorCategory.EXPECTED);
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('should output when verbose is enabled', () => {
+      mockIsVerbose.mockReturnValue(true);
+      logSilentError(new Error('test error'), 'test context', ErrorCategory.EXPECTED);
+
+      expect(stderrSpy).toHaveBeenCalled();
+      const output = stderrSpy.mock.calls[0][0] as string;
+      expect(output).toContain('[silent-expected]');
+      expect(output).toContain('test context');
+      expect(output).toContain('test error');
+    });
+
+    it('should include category in output', () => {
+      mockIsVerbose.mockReturnValue(true);
+      logSilentError(new Error('test'), 'context', ErrorCategory.RETRIABLE);
+
+      const output = stderrSpy.mock.calls[0][0] as string;
+      expect(output).toContain('[silent-retriable]');
+    });
+  });
+});
+
+describe('getSilentErrorSummary', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should return empty summary when no errors', () => {
+    const summary = getSilentErrorSummary();
+
+    expect(summary.total).toBe(0);
+    expect(summary.byCategory[ErrorCategory.EXPECTED]).toBe(0);
+    expect(summary.byCategory[ErrorCategory.RETRIABLE]).toBe(0);
+    expect(summary.byCategory[ErrorCategory.TRANSIENT]).toBe(0);
+    expect(summary.byCategory[ErrorCategory.UNKNOWN]).toBe(0);
+    expect(summary.recentErrors.length).toBe(0);
+  });
+
+  it('should count errors by category', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('3'), 'ctx', ErrorCategory.UNKNOWN);
+
+    const summary = getSilentErrorSummary();
+    expect(summary.total).toBe(3);
+    expect(summary.byCategory[ErrorCategory.EXPECTED]).toBe(2);
+    expect(summary.byCategory[ErrorCategory.UNKNOWN]).toBe(1);
+  });
+
+  it('should include recent errors (last 10)', () => {
+    for (let i = 0; i < 15; i++) {
+      logSilentError(new Error(`error ${i}`), `context ${i}`, ErrorCategory.EXPECTED);
+    }
+
+    const summary = getSilentErrorSummary();
+    expect(summary.recentErrors.length).toBe(10);
+    // Should be the last 10 errors (5-14)
+    expect(summary.recentErrors[0].message).toBe('error 5');
+    expect(summary.recentErrors[9].message).toBe('error 14');
+  });
+});
+
+describe('getAllSilentErrors', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should return all errors', () => {
+    logSilentError(new Error('1'), 'ctx1', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx2', ErrorCategory.UNKNOWN);
+
+    const errors = getAllSilentErrors();
+    expect(errors.length).toBe(2);
+  });
+
+  it('should return a copy (not the original array)', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+
+    const errors1 = getAllSilentErrors();
+    const errors2 = getAllSilentErrors();
+
+    expect(errors1).not.toBe(errors2);
+    expect(errors1).toEqual(errors2);
+  });
+});
+
+describe('clearSilentErrors', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should clear all errors', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.UNKNOWN);
+
+    expect(getSilentErrorCount()).toBe(2);
+
+    clearSilentErrors();
+
+    expect(getSilentErrorCount()).toBe(0);
+    expect(getAllSilentErrors()).toEqual([]);
+  });
+});
+
+describe('getSilentErrorCount', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should return total count when no category specified', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.UNKNOWN);
+
+    expect(getSilentErrorCount()).toBe(2);
+  });
+
+  it('should return count for specific category', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('3'), 'ctx', ErrorCategory.UNKNOWN);
+
+    expect(getSilentErrorCount(ErrorCategory.EXPECTED)).toBe(2);
+    expect(getSilentErrorCount(ErrorCategory.UNKNOWN)).toBe(1);
+    expect(getSilentErrorCount(ErrorCategory.RETRIABLE)).toBe(0);
+  });
+});
+
+describe('hasUnknownErrors', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should return false when no errors', () => {
+    expect(hasUnknownErrors()).toBe(false);
+  });
+
+  it('should return false when only expected errors', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.RETRIABLE);
+
+    expect(hasUnknownErrors()).toBe(false);
+  });
+
+  it('should return true when unknown errors exist', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.UNKNOWN);
+
+    expect(hasUnknownErrors()).toBe(true);
+  });
+});
+
+describe('formatErrorSummary', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should format empty summary', () => {
+    const summary = getSilentErrorSummary();
+    const formatted = formatErrorSummary(summary);
+
+    expect(formatted).toBe('No silent errors logged.');
+  });
+
+  it('should include category counts', () => {
+    logSilentError(new Error('1'), 'ctx', ErrorCategory.EXPECTED);
+    logSilentError(new Error('2'), 'ctx', ErrorCategory.UNKNOWN);
+
+    const summary = getSilentErrorSummary();
+    const formatted = formatErrorSummary(summary);
+
+    expect(formatted).toContain('Silent Error Summary (2 total)');
+    expect(formatted).toContain('Expected:  1');
+    expect(formatted).toContain('Unknown:   1');
+  });
+
+  it('should include recent errors', () => {
+    logSilentError(new Error('test error'), 'test context', ErrorCategory.EXPECTED);
+
+    const summary = getSilentErrorSummary();
+    const formatted = formatErrorSummary(summary);
+
+    expect(formatted).toContain('Recent errors:');
+    expect(formatted).toContain('test context');
+    expect(formatted).toContain('test error');
+  });
+});
+
+describe('error registry limits', () => {
+  beforeEach(() => {
+    clearSilentErrors();
+  });
+
+  it('should limit registry size to prevent memory issues', () => {
+    // Register more than MAX_REGISTRY_SIZE (1000) errors
+    for (let i = 0; i < 1100; i++) {
+      logSilentError(new Error(`error ${i}`), `context ${i}`, ErrorCategory.EXPECTED);
+    }
+
+    const count = getSilentErrorCount();
+    // Should be capped at 1000
+    expect(count).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/insights-middleware.ts
+++ b/src/insights-middleware.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { colors } from './utils/colors.js';
 import { formatDuration } from './utils/formatting.js';
+import { logSilentError, ErrorCategory } from './utils/diagnostics.js';
 
 // Import middleware utilities
 import {
@@ -120,8 +121,9 @@ function loadInsightsData(chadgiDir: string, days?: number): {
     try {
       const content = readFileSync(statsFile, 'utf-8');
       sessions = JSON.parse(content);
-    } catch {
-      // Ignore parse errors
+    } catch (e) {
+      // Stats file may be corrupted or in unexpected format - continue with empty data
+      logSilentError(e, 'parsing session stats for insights', ErrorCategory.EXPECTED);
     }
   }
 
@@ -131,8 +133,9 @@ function loadInsightsData(chadgiDir: string, days?: number): {
       const content = readFileSync(metricsFile, 'utf-8');
       const metricsData: MetricsData = JSON.parse(content);
       tasks = metricsData.tasks || [];
-    } catch {
-      // Ignore parse errors
+    } catch (e) {
+      // Metrics file may be corrupted or in unexpected format - continue with empty data
+      logSilentError(e, 'parsing task metrics for insights', ErrorCategory.EXPECTED);
     }
   }
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -35,6 +35,7 @@ import {
   validateSchema,
   validateArray,
 } from './data-schema.js';
+import { logSilentError, ErrorCategory } from './diagnostics.js';
 
 // ============================================================================
 // Session Stats
@@ -310,8 +311,9 @@ export function findPendingApproval(chadgiDir: string): ApprovalLockData | null 
         return validation.data;
       }
     }
-  } catch {
-    // Directory read error
+  } catch (e) {
+    // Directory read may fail if .chadgi doesn't exist or has permission issues
+    logSilentError(e, 'reading approval lock directory', ErrorCategory.EXPECTED);
   }
   return null;
 }
@@ -348,8 +350,9 @@ export function listApprovalLocks(chadgiDir: string): ApprovalLockData[] {
         approvals.push(validation.data);
       }
     }
-  } catch {
-    // Directory read error
+  } catch (e) {
+    // Directory read may fail if .chadgi doesn't exist or has permission issues
+    logSilentError(e, 'listing approval lock files', ErrorCategory.EXPECTED);
   }
   return approvals;
 }
@@ -456,7 +459,9 @@ export function readTextFile(filePath: string): string | null {
 
   try {
     return readFileSync(filePath, 'utf-8');
-  } catch {
+  } catch (e) {
+    // File read failure is expected when file doesn't exist or is inaccessible
+    logSilentError(e, `reading text file: ${filePath}`, ErrorCategory.EXPECTED);
     return null;
   }
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -194,7 +194,13 @@ function formatData(data: unknown): string {
   } else if (typeof data === 'object' && data !== null) {
     try {
       stringified = JSON.stringify(data, null, 2);
-    } catch {
+    } catch (e) {
+      // JSON.stringify can fail for circular references or BigInt values
+      // This is expected for certain object types, fall back to String()
+      if (isVerbose()) {
+        const errorMsg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`${colors.dim}[silent-expected] formatting debug data: ${errorMsg}${colors.reset}\n`);
+      }
       stringified = String(data);
     }
   } else {

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,0 +1,341 @@
+/**
+ * Diagnostic logging utilities for ChadGI.
+ *
+ * Provides structured logging for silent catch handlers to aid debugging
+ * while maintaining intentional error suppression behavior.
+ *
+ * Usage:
+ * - Replace bare `catch { }` blocks with `catch (e) { logSilentError(e, context, category) }`
+ * - Errors are only logged when verbose mode is enabled
+ * - An in-memory registry tracks all silent errors for diagnostic reporting
+ *
+ * Example:
+ * ```ts
+ * try {
+ *   // Optional parsing that may fail
+ *   const data = JSON.parse(content);
+ * } catch (e) {
+ *   // Parsing is optional, failure is expected for some inputs
+ *   logSilentError(e, 'parsing optional config field', ErrorCategory.EXPECTED);
+ * }
+ * ```
+ */
+
+import { isVerbose } from './debug.js';
+import { colors } from './colors.js';
+
+// ============================================================================
+// Error Categories
+// ============================================================================
+
+/**
+ * Categories for silent errors to help with debugging and diagnostics.
+ *
+ * - EXPECTED: Known/acceptable failures (e.g., optional field missing, fallback path)
+ * - RETRIABLE: Transient failures that may succeed on retry (e.g., rate limiting)
+ * - TRANSIENT: Network/timing issues (e.g., connection timeout, DNS resolution)
+ * - UNKNOWN: Unexpected failures needing investigation
+ */
+export enum ErrorCategory {
+  /** Known/acceptable failures that are part of normal operation */
+  EXPECTED = 'expected',
+  /** Transient failures that may succeed on retry */
+  RETRIABLE = 'retriable',
+  /** Network/timing issues */
+  TRANSIENT = 'transient',
+  /** Unexpected failures needing investigation */
+  UNKNOWN = 'unknown',
+}
+
+// ============================================================================
+// Error Registry
+// ============================================================================
+
+/**
+ * Entry in the silent error registry
+ */
+export interface SilentErrorEntry {
+  /** When the error occurred */
+  timestamp: Date;
+  /** Error message or string representation */
+  message: string;
+  /** Context description of where/why the error occurred */
+  context: string;
+  /** Category of the error */
+  category: ErrorCategory;
+  /** Optional stack trace (only captured for UNKNOWN errors) */
+  stack?: string;
+}
+
+/**
+ * Summary of errors by category
+ */
+export interface ErrorSummary {
+  /** Total number of silent errors logged */
+  total: number;
+  /** Count by category */
+  byCategory: Record<ErrorCategory, number>;
+  /** Recent errors (last N entries) */
+  recentErrors: SilentErrorEntry[];
+}
+
+/**
+ * In-memory registry for tracking silent errors during a session.
+ * This allows diagnostic dumps and summaries without exposing errors
+ * during normal operation.
+ */
+const errorRegistry: SilentErrorEntry[] = [];
+
+/**
+ * Maximum number of errors to keep in the registry to prevent memory issues
+ */
+const MAX_REGISTRY_SIZE = 1000;
+
+/**
+ * Number of recent errors to include in summary
+ */
+const RECENT_ERRORS_COUNT = 10;
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Extract error message from unknown error value.
+ *
+ * @param error - The error value (may be Error, string, or any type)
+ * @returns A string representation of the error
+ */
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/**
+ * Extract stack trace from error if available.
+ *
+ * @param error - The error value
+ * @returns Stack trace string or undefined
+ */
+function extractStack(error: unknown): string | undefined {
+  if (error instanceof Error && error.stack) {
+    return error.stack;
+  }
+  return undefined;
+}
+
+/**
+ * Log a silent error with context for diagnostic purposes.
+ *
+ * This function is designed to replace bare `catch { }` blocks to provide
+ * visibility into intentionally suppressed errors when debugging is enabled.
+ *
+ * The error is:
+ * 1. Logged to stderr (only when verbose mode is enabled)
+ * 2. Registered in the in-memory error registry for diagnostic dumps
+ *
+ * @param error - The error object (can be Error, string, or any value)
+ * @param context - Description of where/why the error occurred
+ * @param category - Category of the error (default: UNKNOWN)
+ *
+ * @example
+ * ```ts
+ * // In a catch block where errors are intentionally suppressed
+ * try {
+ *   const labels = getIssueLabels(issueNumber, repo);
+ * } catch (e) {
+ *   // Label fetching is optional, proceed without labels
+ *   logSilentError(e, 'fetching issue labels', ErrorCategory.EXPECTED);
+ * }
+ * ```
+ */
+export function logSilentError(
+  error: unknown,
+  context: string,
+  category: ErrorCategory = ErrorCategory.UNKNOWN
+): void {
+  const message = extractErrorMessage(error);
+  const entry: SilentErrorEntry = {
+    timestamp: new Date(),
+    message,
+    context,
+    category,
+  };
+
+  // Only capture stack for UNKNOWN errors (unexpected issues)
+  if (category === ErrorCategory.UNKNOWN) {
+    entry.stack = extractStack(error);
+  }
+
+  // Register the error for diagnostic summary
+  registerError(entry);
+
+  // Log to stderr only when verbose mode is enabled
+  if (isVerbose()) {
+    const categoryColor = getCategoryColor(category);
+    const prefix = `${colors.dim}[silent-${category}]${colors.reset}`;
+    const contextStr = `${categoryColor}${context}${colors.reset}`;
+    const messageStr = `${colors.dim}${message}${colors.reset}`;
+
+    process.stderr.write(`${prefix} ${contextStr}: ${messageStr}\n`);
+  }
+}
+
+/**
+ * Get the color code for a category (for terminal output).
+ *
+ * @param category - The error category
+ * @returns ANSI color code string
+ */
+function getCategoryColor(category: ErrorCategory): string {
+  switch (category) {
+    case ErrorCategory.EXPECTED:
+      return colors.dim;
+    case ErrorCategory.RETRIABLE:
+      return colors.yellow;
+    case ErrorCategory.TRANSIENT:
+      return colors.cyan;
+    case ErrorCategory.UNKNOWN:
+      return colors.red;
+    default:
+      return colors.reset;
+  }
+}
+
+// ============================================================================
+// Registry Management
+// ============================================================================
+
+/**
+ * Register an error entry in the in-memory registry.
+ *
+ * @param entry - The error entry to register
+ */
+function registerError(entry: SilentErrorEntry): void {
+  errorRegistry.push(entry);
+
+  // Prevent unbounded growth
+  if (errorRegistry.length > MAX_REGISTRY_SIZE) {
+    // Remove oldest entries when limit is exceeded
+    errorRegistry.splice(0, errorRegistry.length - MAX_REGISTRY_SIZE);
+  }
+}
+
+/**
+ * Get a summary of all silent errors logged during the session.
+ *
+ * This is useful for diagnostic dumps and debugging summaries.
+ *
+ * @returns Summary of errors by category with recent entries
+ *
+ * @example
+ * ```ts
+ * const summary = getSilentErrorSummary();
+ * if (summary.total > 0) {
+ *   console.log(`${summary.total} silent errors occurred`);
+ *   console.log(`Unknown errors: ${summary.byCategory.unknown}`);
+ * }
+ * ```
+ */
+export function getSilentErrorSummary(): ErrorSummary {
+  const byCategory: Record<ErrorCategory, number> = {
+    [ErrorCategory.EXPECTED]: 0,
+    [ErrorCategory.RETRIABLE]: 0,
+    [ErrorCategory.TRANSIENT]: 0,
+    [ErrorCategory.UNKNOWN]: 0,
+  };
+
+  for (const entry of errorRegistry) {
+    byCategory[entry.category]++;
+  }
+
+  return {
+    total: errorRegistry.length,
+    byCategory,
+    recentErrors: errorRegistry.slice(-RECENT_ERRORS_COUNT),
+  };
+}
+
+/**
+ * Get all errors in the registry.
+ *
+ * Use with caution as this returns all entries which could be large.
+ * Prefer getSilentErrorSummary() for diagnostic output.
+ *
+ * @returns Copy of all error entries in the registry
+ */
+export function getAllSilentErrors(): SilentErrorEntry[] {
+  return [...errorRegistry];
+}
+
+/**
+ * Clear all errors from the registry.
+ *
+ * Useful for resetting between test runs or sessions.
+ */
+export function clearSilentErrors(): void {
+  errorRegistry.length = 0;
+}
+
+/**
+ * Get the count of errors by category.
+ *
+ * @param category - The category to count (optional, counts all if not specified)
+ * @returns Number of errors matching the category
+ */
+export function getSilentErrorCount(category?: ErrorCategory): number {
+  if (category === undefined) {
+    return errorRegistry.length;
+  }
+  return errorRegistry.filter((e) => e.category === category).length;
+}
+
+/**
+ * Check if any unknown (unexpected) errors have been logged.
+ *
+ * This is useful for detecting potential bugs that are being silently suppressed.
+ *
+ * @returns true if any UNKNOWN category errors exist
+ */
+export function hasUnknownErrors(): boolean {
+  return errorRegistry.some((e) => e.category === ErrorCategory.UNKNOWN);
+}
+
+/**
+ * Format the error summary for display.
+ *
+ * @param summary - The error summary to format
+ * @returns Formatted string suitable for console output
+ */
+export function formatErrorSummary(summary: ErrorSummary): string {
+  if (summary.total === 0) {
+    return 'No silent errors logged.';
+  }
+
+  const lines: string[] = [];
+  lines.push(`Silent Error Summary (${summary.total} total):`);
+  lines.push(`  Expected:  ${summary.byCategory[ErrorCategory.EXPECTED]}`);
+  lines.push(`  Retriable: ${summary.byCategory[ErrorCategory.RETRIABLE]}`);
+  lines.push(`  Transient: ${summary.byCategory[ErrorCategory.TRANSIENT]}`);
+  lines.push(`  Unknown:   ${summary.byCategory[ErrorCategory.UNKNOWN]}`);
+
+  if (summary.recentErrors.length > 0) {
+    lines.push('');
+    lines.push('Recent errors:');
+    for (const entry of summary.recentErrors) {
+      const time = entry.timestamp.toISOString().split('T')[1].split('.')[0];
+      lines.push(`  [${time}] [${entry.category}] ${entry.context}: ${entry.message}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/utils/fileOps.ts
+++ b/src/utils/fileOps.ts
@@ -13,6 +13,7 @@ import { writeFileSync, renameSync, unlinkSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { isVerbose } from './debug.js';
 import type { DataSchema, ValidationResult } from './data-schema.js';
+import { logSilentError, ErrorCategory } from './diagnostics.js';
 
 /**
  * Default number of retry attempts for transient failures
@@ -104,8 +105,9 @@ export function atomicWriteFile(filePath: string, content: string): void {
       if (existsSync(tempPath)) {
         unlinkSync(tempPath);
       }
-    } catch {
-      // Ignore cleanup errors - the original error is more important
+    } catch (cleanupError) {
+      // Cleanup errors are secondary - the original error takes priority
+      logSilentError(cleanupError, `cleaning up temp file ${tempPath}`, ErrorCategory.EXPECTED);
     }
 
     // Re-throw the original error

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -417,3 +417,20 @@ export {
   isStandardOption,
   hasOption,
 } from './cli-options.js';
+
+// Diagnostics (silent error logging)
+export {
+  // Types
+  ErrorCategory,
+  type SilentErrorEntry,
+  type ErrorSummary,
+  // Core functions
+  logSilentError,
+  // Registry functions
+  getSilentErrorSummary,
+  getAllSilentErrors,
+  clearSilentErrors,
+  getSilentErrorCount,
+  hasUnknownErrors,
+  formatErrorSummary,
+} from './diagnostics.js';

--- a/src/utils/json-output.ts
+++ b/src/utils/json-output.ts
@@ -47,6 +47,8 @@
  * ```
  */
 
+import { logSilentError, ErrorCategory } from './diagnostics.js';
+
 // Get package version for meta information
 let _packageVersion: string | null = null;
 
@@ -74,13 +76,15 @@ function getPackageVersion(): string {
           _packageVersion = pkg.version as string;
           return _packageVersion;
         }
-      } catch {
-        // Continue searching up
+      } catch (e) {
+        // Package.json not found at this level, continue searching up
+        logSilentError(e, `reading package.json from ${searchDir}`, ErrorCategory.EXPECTED);
       }
       searchDir = dirname(searchDir);
     }
-  } catch {
-    // Ignore errors, use fallback
+  } catch (e) {
+    // Module resolution failed, use fallback version
+    logSilentError(e, 'loading fs/path modules for version detection', ErrorCategory.EXPECTED);
   }
 
   _packageVersion = 'unknown';


### PR DESCRIPTION
## Summary
- Create `src/utils/diagnostics.ts` with `ErrorCategory` enum (`EXPECTED`, `RETRIABLE`, `TRANSIENT`, `UNKNOWN`)
- Implement `logSilentError()` function that logs to stderr when verbose mode is enabled
- Add in-memory error registry for diagnostic summaries (capped at 1000 entries to prevent memory issues)
- Update silent catch blocks across 6 files with structured diagnostic logging:
  - `src/queue.ts` - 6 catch handlers (label/body/dependency/project board operations)
  - `src/utils/data.ts` - 3 catch handlers (approval lock directory operations)
  - `src/insights-middleware.ts` - 2 catch handlers (session/metrics JSON parsing)
  - `src/utils/fileOps.ts` - 1 catch handler (temp file cleanup)
  - `src/utils/json-output.ts` - 2 catch handlers (package.json version detection)
  - `src/utils/debug.ts` - 1 inline handler (JSON.stringify circular reference fallback)
- Export new diagnostics module from `src/utils/index.ts`
- Add comprehensive unit tests (30+ test cases) in `src/__tests__/utils/diagnostics.test.ts`

## Test Plan
- [x] Run `npm run test:unit` - All 1188 tests pass
- [x] Run `npm run build` - TypeScript compiles without errors
- [ ] Verify diagnostic output with `--verbose` flag: Run any command that triggers silent catches (e.g., `chadgi queue` with network issues) and confirm `[silent-expected]` messages appear in stderr
- [ ] Verify no output without verbose: Same command without `--verbose` should produce no diagnostic output

Closes #131

---
\`\`\`
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
\`\`\`
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a structured diagnostics system for silent catch handlers with opt-in verbose output and session-scoped tracking.
> 
> - New `utils/diagnostics.ts`: `ErrorCategory`, `logSilentError`, in-memory registry (capped at 1000), summaries (`getSilentErrorSummary`, `formatErrorSummary`), and helpers
> - Integrations: replace bare catches to log contextually in `queue.ts` (labels/body/status/project ops), `insights-middleware.ts` (stats/metrics parsing), `utils/data.ts` (approval lock reads/lists), `utils/fileOps.ts` (temp cleanup), `utils/json-output.ts` (version detection), `utils/debug.ts` (JSON.stringify fallback)
> - Export diagnostics from `utils/index.ts` for reuse
> - Tests: add `__tests__/utils/diagnostics.test.ts` covering categories, registry, verbose output, summaries, and limits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5f93297bee3458afce30205cb5475761d8a3467. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->