### PR TITLE
[CHAD] Add operation context attachment for enriched error diagnostics

### DIFF
--- a/src/__tests__/utils/error-context.test.ts
+++ b/src/__tests__/utils/error-context.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Unit tests for error context attachment utilities.
+ *
+ * Tests the ErrorContext system including:
+ * - createErrorContext
+ * - attachContext
+ * - withContext (sync)
+ * - withContextAsync (async)
+ * - ChadGIError.toJSON() with context
+ * - serializeError
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  ChadGIError,
+  ConfigError,
+  GitHubError,
+  createErrorContext,
+  attachContext,
+  withContext,
+  withContextAsync,
+  hasErrorContext,
+  getErrorContext,
+  serializeError,
+  type ErrorContext,
+  type ErrorContextIdentifiers,
+} from '../../utils/errors.js';
+
+describe('Error Context Utilities', () => {
+  describe('createErrorContext', () => {
+    it('should create context with operation and current timestamp', () => {
+      const before = new Date();
+      const context = createErrorContext({ operation: 'file-read' });
+      const after = new Date();
+
+      expect(context.operation).toBe('file-read');
+      expect(context.startedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(context.startedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      expect(context.identifiers).toBeUndefined();
+      expect(context.metadata).toBeUndefined();
+    });
+
+    it('should create context with identifiers', () => {
+      const context = createErrorContext({
+        operation: 'github-issue',
+        identifiers: { issueNumber: 42, repo: 'owner/repo' },
+      });
+
+      expect(context.operation).toBe('github-issue');
+      expect(context.identifiers).toEqual({ issueNumber: 42, repo: 'owner/repo' });
+    });
+
+    it('should create context with metadata', () => {
+      const context = createErrorContext({
+        operation: 'queue-process',
+        identifiers: { taskId: 'task-123' },
+        metadata: { retryCount: 3, lastAttempt: 'failed' },
+      });
+
+      expect(context.operation).toBe('queue-process');
+      expect(context.metadata).toEqual({ retryCount: 3, lastAttempt: 'failed' });
+    });
+
+    it('should support custom operation types', () => {
+      const context = createErrorContext({
+        operation: 'custom-operation',
+        identifiers: { filePath: '/path/to/file' },
+      });
+
+      expect(context.operation).toBe('custom-operation');
+    });
+  });
+
+  describe('attachContext', () => {
+    it('should attach context to ChadGIError and compute duration', async () => {
+      const context = createErrorContext({
+        operation: 'file-read',
+        identifiers: { filePath: '/test/file.json' },
+      });
+
+      // Wait a bit to ensure duration is measurable
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const error = new ChadGIError('File not found', 'FILE_NOT_FOUND');
+      const enriched = attachContext(error, context);
+
+      expect(enriched).toBe(error); // Same object
+      expect(enriched.context).toBeDefined();
+      expect(enriched.context!.operation).toBe('file-read');
+      expect(enriched.context!.identifiers).toEqual({ filePath: '/test/file.json' });
+      expect(enriched.context!.durationMs).toBeGreaterThanOrEqual(10);
+    });
+
+    it('should wrap generic Error in ChadGIError with context', () => {
+      const context = createErrorContext({
+        operation: 'github-api',
+        identifiers: { endpoint: '/repos/owner/repo/issues' },
+      });
+
+      const genericError = new Error('Network timeout');
+      genericError.stack = 'Error: Network timeout\n    at test.js:42';
+
+      const enriched = attachContext(genericError, context);
+
+      expect(enriched).toBeInstanceOf(ChadGIError);
+      expect(enriched.message).toBe('Network timeout');
+      expect(enriched.code).toBe('UNKNOWN_ERROR');
+      expect(enriched.stack).toContain('test.js:42');
+      expect(enriched.context).toBeDefined();
+      expect(enriched.context!.operation).toBe('github-api');
+    });
+
+    it('should handle non-Error values', () => {
+      const context = createErrorContext({ operation: 'shell-exec' });
+
+      const enriched = attachContext('Something went wrong', context);
+
+      expect(enriched).toBeInstanceOf(ChadGIError);
+      expect(enriched.message).toBe('Something went wrong');
+      expect(enriched.code).toBe('UNKNOWN_ERROR');
+      expect(enriched.context).toBeDefined();
+    });
+
+    it('should handle undefined/null values', () => {
+      const context = createErrorContext({ operation: 'config-parse' });
+
+      const enriched1 = attachContext(undefined, context);
+      expect(enriched1.message).toBe('undefined');
+
+      const enriched2 = attachContext(null, context);
+      expect(enriched2.message).toBe('null');
+    });
+
+    it('should preserve existing ChadGIError subclass properties', () => {
+      const context = createErrorContext({
+        operation: 'github-api',
+        identifiers: { repo: 'owner/repo' },
+      });
+
+      const error = new GitHubError('API rate limit exceeded');
+      const enriched = attachContext(error, context);
+
+      expect(enriched).toBe(error);
+      expect(enriched.code).toBe('GITHUB_ERROR');
+      expect(enriched.context!.operation).toBe('github-api');
+    });
+  });
+
+  describe('hasErrorContext / getErrorContext', () => {
+    it('hasErrorContext returns true for ChadGIError with context', () => {
+      const error = new ChadGIError('Test error', 'TEST_ERROR');
+      error.context = createErrorContext({ operation: 'test' });
+
+      expect(hasErrorContext(error)).toBe(true);
+    });
+
+    it('hasErrorContext returns false for ChadGIError without context', () => {
+      const error = new ChadGIError('Test error', 'TEST_ERROR');
+      expect(hasErrorContext(error)).toBe(false);
+    });
+
+    it('hasErrorContext returns false for generic Error', () => {
+      const error = new Error('Generic error');
+      expect(hasErrorContext(error)).toBe(false);
+    });
+
+    it('getErrorContext returns context when present', () => {
+      const error = new ChadGIError('Test error', 'TEST_ERROR');
+      const ctx = createErrorContext({ operation: 'file-write' });
+      error.context = ctx;
+
+      expect(getErrorContext(error)).toBe(ctx);
+    });
+
+    it('getErrorContext returns undefined when no context', () => {
+      const error = new ChadGIError('Test error', 'TEST_ERROR');
+      expect(getErrorContext(error)).toBeUndefined();
+
+      const genericError = new Error('Generic');
+      expect(getErrorContext(genericError)).toBeUndefined();
+    });
+  });
+
+  describe('withContext (sync)', () => {
+    it('should return result when function succeeds', () => {
+      const result = withContext(
+        'file-read',
+        { filePath: '/test/file.txt' },
+        () => 'file content'
+      );
+
+      expect(result).toBe('file content');
+    });
+
+    it('should attach context when function throws', () => {
+      expect(() => {
+        withContext(
+          'file-read',
+          { filePath: '/nonexistent/file.txt' },
+          () => {
+            throw new Error('ENOENT: no such file');
+          }
+        );
+      }).toThrow(ChadGIError);
+
+      try {
+        withContext(
+          'file-read',
+          { filePath: '/nonexistent/file.txt' },
+          () => {
+            throw new Error('ENOENT: no such file');
+          }
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChadGIError);
+        const chadError = error as ChadGIError;
+        expect(chadError.context).toBeDefined();
+        expect(chadError.context!.operation).toBe('file-read');
+        expect(chadError.context!.identifiers).toEqual({ filePath: '/nonexistent/file.txt' });
+      }
+    });
+
+    it('should preserve ChadGIError and attach context', () => {
+      try {
+        withContext(
+          'config-load',
+          { filePath: '/config.yaml' },
+          () => {
+            throw new ConfigError('Invalid config format');
+          }
+        );
+      } catch (error) {
+        const chadError = error as ChadGIError;
+        expect(chadError).toBeInstanceOf(ConfigError);
+        expect(chadError.code).toBe('CONFIG_ERROR');
+        expect(chadError.context!.operation).toBe('config-load');
+      }
+    });
+
+    it('should include metadata when provided', () => {
+      try {
+        withContext(
+          'file-write',
+          { filePath: '/test.json' },
+          () => {
+            throw new Error('Disk full');
+          },
+          { contentType: 'json', size: 1024 }
+        );
+      } catch (error) {
+        const chadError = error as ChadGIError;
+        expect(chadError.context!.metadata).toEqual({ contentType: 'json', size: 1024 });
+      }
+    });
+
+    it('should work with undefined identifiers', () => {
+      const result = withContext('shell-exec', undefined, () => 42);
+      expect(result).toBe(42);
+    });
+  });
+
+  describe('withContextAsync', () => {
+    it('should return result when async function succeeds', async () => {
+      const result = await withContextAsync(
+        'github-api',
+        { repo: 'owner/repo', endpoint: '/issues' },
+        async () => {
+          await new Promise(resolve => setTimeout(resolve, 5));
+          return { issues: [] };
+        }
+      );
+
+      expect(result).toEqual({ issues: [] });
+    });
+
+    it('should attach context when async function rejects', async () => {
+      await expect(
+        withContextAsync(
+          'github-issue',
+          { issueNumber: 42, repo: 'owner/repo' },
+          async () => {
+            throw new Error('Issue not found');
+          }
+        )
+      ).rejects.toThrow(ChadGIError);
+
+      try {
+        await withContextAsync(
+          'github-issue',
+          { issueNumber: 42, repo: 'owner/repo' },
+          async () => {
+            throw new Error('Issue not found');
+          }
+        );
+      } catch (error) {
+        const chadError = error as ChadGIError;
+        expect(chadError.context).toBeDefined();
+        expect(chadError.context!.operation).toBe('github-issue');
+        expect(chadError.context!.identifiers).toEqual({ issueNumber: 42, repo: 'owner/repo' });
+        expect(chadError.context!.durationMs).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('should include metadata in async context', async () => {
+      try {
+        await withContextAsync(
+          'queue-fetch',
+          { taskId: 'task-123' },
+          async () => {
+            throw new Error('Queue timeout');
+          },
+          { attempt: 3, timeout: 5000 }
+        );
+      } catch (error) {
+        const chadError = error as ChadGIError;
+        expect(chadError.context!.metadata).toEqual({ attempt: 3, timeout: 5000 });
+      }
+    });
+  });
+
+  describe('ChadGIError.toJSON()', () => {
+    it('should serialize error without context', () => {
+      const error = new ChadGIError('Something failed', 'GENERIC_ERROR');
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        name: 'ChadGIError',
+        code: 'GENERIC_ERROR',
+        message: 'Something failed',
+      });
+    });
+
+    it('should serialize error with context', () => {
+      const error = new ChadGIError('File not found', 'FILE_NOT_FOUND');
+      error.context = {
+        operation: 'file-read',
+        identifiers: { filePath: '/path/to/file.json' },
+        startedAt: new Date('2026-01-15T10:30:00.000Z'),
+        durationMs: 42,
+        metadata: { encoding: 'utf-8' },
+      };
+
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        name: 'ChadGIError',
+        code: 'FILE_NOT_FOUND',
+        message: 'File not found',
+        context: {
+          operation: 'file-read',
+          identifiers: { filePath: '/path/to/file.json' },
+          startedAt: '2026-01-15T10:30:00.000Z',
+          durationMs: 42,
+          metadata: { encoding: 'utf-8' },
+        },
+      });
+    });
+
+    it('should serialize subclass with context', () => {
+      const error = new GitHubError('API error');
+      error.context = {
+        operation: 'github-api',
+        identifiers: { repo: 'owner/repo' },
+        startedAt: new Date('2026-01-15T10:30:00.000Z'),
+        durationMs: 100,
+      };
+
+      const json = error.toJSON();
+
+      expect(json.name).toBe('GitHubError');
+      expect(json.code).toBe('GITHUB_ERROR');
+      expect(json.context).toBeDefined();
+    });
+  });
+
+  describe('serializeError', () => {
+    it('should serialize ChadGIError using toJSON', () => {
+      const error = new ChadGIError('Test error', 'TEST_ERROR');
+      error.context = createErrorContext({ operation: 'test' });
+
+      const serialized = serializeError(error);
+
+      expect(serialized.name).toBe('ChadGIError');
+      expect(serialized.code).toBe('TEST_ERROR');
+      expect(serialized.context).toBeDefined();
+    });
+
+    it('should serialize generic Error', () => {
+      const error = new Error('Generic error');
+      const serialized = serializeError(error);
+
+      expect(serialized).toEqual({
+        name: 'Error',
+        message: 'Generic error',
+        code: 'UNKNOWN_ERROR',
+      });
+    });
+
+    it('should serialize non-Error values', () => {
+      expect(serializeError('string error')).toEqual({
+        name: 'Error',
+        message: 'string error',
+        code: 'UNKNOWN_ERROR',
+      });
+
+      expect(serializeError(42)).toEqual({
+        name: 'Error',
+        message: '42',
+        code: 'UNKNOWN_ERROR',
+      });
+
+      expect(serializeError(null)).toEqual({
+        name: 'Error',
+        message: 'null',
+        code: 'UNKNOWN_ERROR',
+      });
+    });
+  });
+
+  describe('Integration: Full error flow', () => {
+    it('should handle complete error lifecycle with context', async () => {
+      // Simulate a file operation that fails
+      const performFileOperation = async (path: string): Promise<string> => {
+        return withContextAsync(
+          'file-read',
+          { filePath: path },
+          async () => {
+            await new Promise(resolve => setTimeout(resolve, 5));
+            throw new Error('ENOENT: no such file or directory');
+          },
+          { encoding: 'utf-8' }
+        );
+      };
+
+      try {
+        await performFileOperation('/nonexistent/config.json');
+        expect(true).toBe(false); // Should not reach here
+      } catch (error) {
+        // Verify error is properly enriched
+        expect(error).toBeInstanceOf(ChadGIError);
+        const chadError = error as ChadGIError;
+
+        // Check context
+        expect(chadError.context).toBeDefined();
+        expect(chadError.context!.operation).toBe('file-read');
+        expect(chadError.context!.identifiers!.filePath).toBe('/nonexistent/config.json');
+        expect(chadError.context!.metadata!.encoding).toBe('utf-8');
+        expect(chadError.context!.durationMs).toBeGreaterThanOrEqual(5);
+
+        // Verify serialization for JSON output
+        const serialized = chadError.toJSON();
+        expect(serialized.context).toBeDefined();
+        expect((serialized.context as Record<string, unknown>).startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      }
+    });
+  });
+});

--- a/src/__tests__/utils/fileOps.test.ts
+++ b/src/__tests__/utils/fileOps.test.ts
@@ -36,6 +36,10 @@ jest.unstable_mockModule('fs', () => ({
       vol.writeFileSync(path, content);
     }
   }),
+  readFileSync: jest.fn((path: string, encoding?: string) => {
+    // Default implementation using memfs
+    return vol.readFileSync(path, encoding);
+  }),
   renameSync: jest.fn((oldPath: string, newPath: string) => {
     if (renameSyncImpl) {
       renameSyncImpl(oldPath, newPath);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,21 +5,124 @@
  * across all command modules.
  */
 
+// ============================================================================
+// Operation Context Types
+// ============================================================================
+
+/**
+ * Common operation types for context attachment.
+ * Using a union type allows for extensibility while providing intellisense.
+ */
+export type OperationType =
+  | 'file-read'
+  | 'file-write'
+  | 'file-delete'
+  | 'github-api'
+  | 'github-issue'
+  | 'github-pr'
+  | 'github-project'
+  | 'queue-fetch'
+  | 'queue-process'
+  | 'config-load'
+  | 'config-parse'
+  | 'shell-exec'
+  | 'lock-acquire'
+  | 'lock-release'
+  | string; // Allow custom operation types
+
+/**
+ * Relevant identifiers for the operation being performed.
+ * All fields are optional since different operations need different identifiers.
+ */
+export interface ErrorContextIdentifiers {
+  /** File path for file operations */
+  filePath?: string;
+  /** GitHub issue number */
+  issueNumber?: number;
+  /** GitHub PR number */
+  prNumber?: number;
+  /** Task ID for queue operations */
+  taskId?: string;
+  /** Repository in owner/repo format */
+  repo?: string;
+  /** GitHub project number */
+  projectNumber?: number | string;
+  /** Session ID for lock operations */
+  sessionId?: string;
+  /** API endpoint for GitHub API calls */
+  endpoint?: string;
+  /** Shell command that was executed */
+  command?: string;
+}
+
+/**
+ * Context information attached to errors for enriched diagnostics.
+ *
+ * This provides operational metadata that helps with debugging:
+ * - What operation was being performed
+ * - What resources were involved
+ * - When the operation started
+ * - Any additional context-specific metadata
+ */
+export interface ErrorContext {
+  /** Operation being performed (e.g., 'file-read', 'github-api', 'queue-fetch') */
+  operation: OperationType;
+  /** Relevant identifiers for the operation */
+  identifiers?: ErrorContextIdentifiers;
+  /** Timestamp when the operation started */
+  startedAt: Date;
+  /** Duration in milliseconds from start to error (computed when context is attached) */
+  durationMs?: number;
+  /** Additional context metadata (should be sanitized of sensitive data) */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Error Classes
+// ============================================================================
+
 /**
  * Base error class for all ChadGI errors
  */
 export class ChadGIError extends Error {
   public readonly code: string;
+  /** Optional operation context for enriched diagnostics */
+  public context?: ErrorContext;
 
-  constructor(message: string, code: string) {
+  constructor(message: string, code: string, context?: ErrorContext) {
     super(message);
     this.name = 'ChadGIError';
     this.code = code;
+    this.context = context;
 
     // Maintains proper stack trace in V8
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ChadGIError);
     }
+  }
+
+  /**
+   * Serialize error to a plain object for JSON output.
+   * Includes context information if present.
+   */
+  toJSON(): Record<string, unknown> {
+    const result: Record<string, unknown> = {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+    };
+
+    if (this.context) {
+      result.context = {
+        operation: this.context.operation,
+        identifiers: this.context.identifiers,
+        startedAt: this.context.startedAt.toISOString(),
+        durationMs: this.context.durationMs,
+        metadata: this.context.metadata,
+      };
+    }
+
+    return result;
   }
 }
 
@@ -222,4 +325,215 @@ export function getErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+// ============================================================================
+// Context Attachment Utilities
+// ============================================================================
+
+/**
+ * Options for creating an error context.
+ */
+export interface CreateContextOptions {
+  /** Operation being performed */
+  operation: OperationType;
+  /** Relevant identifiers for the operation */
+  identifiers?: ErrorContextIdentifiers;
+  /** Additional metadata (will be sanitized) */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Create an ErrorContext with the current timestamp.
+ *
+ * @param options - Context creation options
+ * @returns A new ErrorContext object
+ *
+ * @example
+ * ```typescript
+ * const ctx = createErrorContext({
+ *   operation: 'file-read',
+ *   identifiers: { filePath: '/path/to/file.json' }
+ * });
+ * ```
+ */
+export function createErrorContext(options: CreateContextOptions): ErrorContext {
+  return {
+    operation: options.operation,
+    identifiers: options.identifiers,
+    startedAt: new Date(),
+    metadata: options.metadata,
+  };
+}
+
+/**
+ * Attach context to an error, enriching it with operational metadata.
+ *
+ * If the error is a ChadGIError, the context is attached directly.
+ * If it's a generic Error, a new ChadGIError is created wrapping it.
+ * If it's neither, the value is converted to a string message.
+ *
+ * The context's durationMs is computed from startedAt to now.
+ *
+ * @param error - The error to enrich
+ * @param context - The context to attach
+ * @returns The enriched error (may be the same object if ChadGIError)
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await readFile(path);
+ * } catch (error) {
+ *   throw attachContext(error, context);
+ * }
+ * ```
+ */
+export function attachContext(error: unknown, context: ErrorContext): ChadGIError {
+  // Compute duration from context start time
+  const enrichedContext: ErrorContext = {
+    ...context,
+    durationMs: Date.now() - context.startedAt.getTime(),
+  };
+
+  // If already a ChadGIError, attach context and return
+  if (isChadGIError(error)) {
+    error.context = enrichedContext;
+    return error;
+  }
+
+  // If it's a generic Error, wrap it in a ChadGIError
+  if (error instanceof Error) {
+    const wrapped = new ChadGIError(error.message, 'UNKNOWN_ERROR', enrichedContext);
+    wrapped.stack = error.stack;
+    return wrapped;
+  }
+
+  // For non-Error values, create a new ChadGIError
+  return new ChadGIError(String(error), 'UNKNOWN_ERROR', enrichedContext);
+}
+
+/**
+ * Check if an error has context attached.
+ */
+export function hasErrorContext(error: unknown): error is ChadGIError & { context: ErrorContext } {
+  return isChadGIError(error) && error.context !== undefined;
+}
+
+/**
+ * Get error context from an error, if present.
+ */
+export function getErrorContext(error: unknown): ErrorContext | undefined {
+  if (isChadGIError(error)) {
+    return error.context;
+  }
+  return undefined;
+}
+
+/**
+ * Wrap a synchronous operation with automatic context attachment on failure.
+ *
+ * This is a higher-order function that creates an ErrorContext before executing
+ * the operation, and automatically attaches it to any thrown error.
+ *
+ * @param operation - The operation type
+ * @param identifiers - Relevant identifiers for the operation
+ * @param fn - The function to execute
+ * @param metadata - Optional additional metadata
+ * @returns The result of fn()
+ * @throws ChadGIError with context attached if fn() throws
+ *
+ * @example
+ * ```typescript
+ * const data = withContext(
+ *   'file-read',
+ *   { filePath: '/path/to/config.json' },
+ *   () => readFileSync('/path/to/config.json', 'utf-8')
+ * );
+ * ```
+ */
+export function withContext<T>(
+  operation: OperationType,
+  identifiers: ErrorContextIdentifiers | undefined,
+  fn: () => T,
+  metadata?: Record<string, unknown>
+): T {
+  const context = createErrorContext({
+    operation,
+    identifiers,
+    metadata,
+  });
+
+  try {
+    return fn();
+  } catch (error) {
+    throw attachContext(error, context);
+  }
+}
+
+/**
+ * Wrap an asynchronous operation with automatic context attachment on failure.
+ *
+ * This is the async version of withContext, suitable for Promise-returning operations.
+ *
+ * @param operation - The operation type
+ * @param identifiers - Relevant identifiers for the operation
+ * @param fn - The async function to execute
+ * @param metadata - Optional additional metadata
+ * @returns Promise resolving to the result of fn()
+ * @throws ChadGIError with context attached if fn() rejects
+ *
+ * @example
+ * ```typescript
+ * const issue = await withContextAsync(
+ *   'github-issue',
+ *   { issueNumber: 42, repo: 'owner/repo' },
+ *   () => gh.issue.get(42, 'owner/repo')
+ * );
+ * ```
+ */
+export async function withContextAsync<T>(
+  operation: OperationType,
+  identifiers: ErrorContextIdentifiers | undefined,
+  fn: () => Promise<T>,
+  metadata?: Record<string, unknown>
+): Promise<T> {
+  const context = createErrorContext({
+    operation,
+    identifiers,
+    metadata,
+  });
+
+  try {
+    return await fn();
+  } catch (error) {
+    throw attachContext(error, context);
+  }
+}
+
+/**
+ * Serialize an error with context to a plain object suitable for JSON output.
+ *
+ * This handles both ChadGIError (using toJSON) and generic errors.
+ *
+ * @param error - The error to serialize
+ * @returns Plain object representation of the error
+ */
+export function serializeError(error: unknown): Record<string, unknown> {
+  if (isChadGIError(error)) {
+    return error.toJSON();
+  }
+
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: 'UNKNOWN_ERROR',
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(error),
+    code: 'UNKNOWN_ERROR',
+  };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,6 +25,7 @@ export {
 
 // Errors
 export {
+  // Error classes
   ChadGIError,
   ConfigError,
   ConfigNotFoundError,
@@ -38,9 +39,23 @@ export {
   BudgetExceededError,
   TaskTimeoutError,
   MaxIterationsError,
+  // Error utilities
   isChadGIError,
   getErrorCode,
   getErrorMessage,
+  // Error context types
+  type OperationType,
+  type ErrorContextIdentifiers,
+  type ErrorContext,
+  type CreateContextOptions as CreateErrorContextOptions,
+  // Error context functions
+  createErrorContext,
+  attachContext,
+  hasErrorContext,
+  getErrorContext,
+  withContext,
+  withContextAsync,
+  serializeError,
 } from './errors.js';
 
 // Formatting
@@ -163,12 +178,24 @@ export {
 
 // File Operations (atomic writes and safe parsing)
 export {
+  // Atomic write functions
   atomicWriteFile,
   atomicWriteJson,
+  // Safe write functions with retry
   safeWriteFile,
   safeWriteJson,
+  // Safe parsing functions
   safeParseJson,
   safeParseAndValidate,
+  // Context-aware file operations
+  readFileWithContext,
+  writeFileWithContext,
+  writeJsonWithContext,
+  safeWriteFileWithContext,
+  safeWriteJsonWithContext,
+  existsWithContext,
+  deleteFileWithContext,
+  // Types
   type SafeWriteOptions,
   type SafeParseSuccess,
   type SafeParseFailure,
@@ -385,10 +412,12 @@ export {
   type CreateJsonResponseOptions,
   type CreateJsonErrorOptions,
   type ErrorCode,
+  type SerializedErrorContext,
   // Factory functions
   createResponseMeta,
   createJsonResponse,
   createJsonError,
+  createJsonErrorFromError,
   // Error codes
   ErrorCodes,
   // Type guards


### PR DESCRIPTION
## Summary
- Add `ErrorContext` interface to capture operational metadata (operation type, identifiers, timestamps, duration, metadata)
- Update `ChadGIError` class with optional context property and `toJSON()` serialization
- Create `attachContext()` helper to enrich any error with context information
- Add `withContext()` and `withContextAsync()` wrappers for automatic context attachment on failure
- Create helper functions: `createErrorContext`, `hasErrorContext`, `getErrorContext`, `serializeError`
- Integrate context in file operations (`fileOps.ts`): `readFileWithContext`, `writeFileWithContext`, etc.
- Integrate context in GitHub API calls (`gh-client.ts`): `GhClientError.fromErrorWithContext`
- Integrate context in queue operations (`queue.ts`): Context tracking in `queueSkip` and `queuePromote`
- Update JSON output with `SerializedErrorContext` interface and `createJsonErrorFromError()` function
- Add comprehensive test suite (29 tests) for all context utilities

## Test Plan
- [x] Run `npm run build` - TypeScript compiles successfully
- [x] Run `npm test` - All 1184 unit tests pass, 25 integration tests pass
- [x] Run `npm run test:unit -- --testPathPatterns="error-context"` - All 29 new tests pass
- [x] Verify error context appears in JSON output when errors occur in file/GitHub/queue operations

Closes #132

---
```
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠋⠉⠈⠉⠉⠉⠉⠛⠻⢿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⢿⣿⣿⣿⣿
⣿⣿⣿⣿⡏⣀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣿⣿
⣿⣿⣿⢏⣴⣿⣷⠀⠀⠀⠀⠀⢾⣿⣿⣿⣿⣿⣿⡆⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿
⣿⣿⣟⣾⣿⡟⠁⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣷⢢⠀⠀⠀⠀⠀⠀⠀⢸⣿
⣿⣿⣿⣿⣟⠀⡴⠄⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀⠀⣿
⣿⣿⣿⠟⠻⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢴⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⣿
⣿⣁⡀⠀⠀⢰⢠⣦⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⣿⣿⣿⣿⡄⠀⣴⣶⣿⡄⣿
⣿⡋⠀⠀⠀⠎⢸⣿⡆⠀⠀⠀⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠗⢘⣿⣟⠛⠿⣼
⣿⣿⠋⢀⡌⢰⣿⡿⢿⡀⠀⠀⠀⠀⠀⠙⠿⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣧⢀⣼
⣿⣿⣷⢻⠄⠘⠛⠋⠛⠃⠀⠀⠀⠀⠀⢿⣧⠈⠉⠙⠛⠋⠀⠀⠀⣿⣿⣿⣿⣿
⣿⣿⣧⠀⠈⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠟⠀⠀⠀⠀⢀⢃⠀⠀⢸⣿⣿⣿⣿
⣿⣿⡿⠀⠴⢗⣠⣤⣴⡶⠶⠖⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⡸⠀⣿⣿⣿⣿
⣿⣿⣿⡀⢠⣾⣿⠏⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⠉⠀⣿⣿⣿⣿
⣿⣿⣿⣧⠈⢹⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿
⣿⣿⣿⣿⡄⠈⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣧⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣦⣄⣀⣀⣀⣀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡄⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀⠀⠀⠙⣿⣿⡟⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⠁⠀⠀⠹⣿⠃⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⢐⣿⣿⣿⣿⣿⣿⣿⣿⣿
⣿⣿⣿⣿⠿⠛⠉⠉⠁⠀⢻⣿⡇⠀⠀⠀⠀⠀⠀⢀⠈⣿⣿⡿⠉⠛⠛⠛⠉⠉
⣿⡿⠋⠁⠀⠀⢀⣀⣠⡴⣸⣿⣇⡄⠀⠀⠀⠀⢀⡿⠄⠙⠛⠀⣀⣠⣤⣤⠄
```
_Chad does what Chad wants. No humans mass-produced in the mass-production of this PR._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds structured `ErrorContext` and utilities for enriched diagnostics across the codebase.
> 
> - **New error context system**: `OperationType`, `ErrorContext(Identifiers)`, `createErrorContext`, `attachContext`, `withContext`, `withContextAsync`, `hasErrorContext`, `getErrorContext`, `serializeError`; `ChadGIError` now carries `context` and serializes via `toJSON()`
> - **GitHub client integration**: `GhClientError` now serializes context; new `fromErrorWithContext`; applied to issue `create/update/close` paths
> - **File operations integration**: context-aware wrappers `readFileWithContext`, `writeFileWithContext`, `writeJsonWithContext`, `safeWriteFileWithContext`, `safeWriteJsonWithContext`, `existsWithContext`, `deleteFileWithContext`
> - **Queue commands**: `queueSkip`/`queuePromote` attach operation context and include it in JSON failure output
> - **JSON output**: adds `SerializedErrorContext` and `createJsonErrorFromError` to surface context in API responses
> - **Tests**: new comprehensive `error-context` unit tests; minor fs mock update in `fileOps.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b566a3070f15a14e052bfc158bed67c0e64aced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->